### PR TITLE
fix: truncate news title if over two lines

### DIFF
--- a/lib/ui/views/news/news-feed/news_feed_view.dart
+++ b/lib/ui/views/news/news-feed/news_feed_view.dart
@@ -44,6 +44,7 @@ class NewsFeedView extends StatelessWidget {
         separatorBuilder: (context, int i) => const Divider(
               color: Color.fromRGBO(0x2A, 0x2A, 0x40, 1),
               thickness: 3,
+              height: 3,
             ),
         itemBuilder: (BuildContext contex, int i) => NewsFeedLazyLoading(
             articleCreated: () {
@@ -107,8 +108,12 @@ class NewsFeedView extends StatelessWidget {
                       padding: const EdgeInsets.all(16.0),
                       child: Text(
                         articles[i].title,
-                        style:
-                            const TextStyle(color: Colors.white, fontSize: 20),
+                        maxLines: 2,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 20,
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     ),
                   )


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46919888/145707318-a930253d-ff2e-4e17-8efc-414941961336.png)

there seems to be a build in truncate function for text. 