### PR TITLE
Fixed SafeArea issue on Drawer & WebView Screen, Issue in mobiles having notch or Punch hole camera

### DIFF
--- a/lib/ui/views/browser/browser_view.dart
+++ b/lib/ui/views/browser/browser_view.dart
@@ -16,20 +16,22 @@ class BrowserView extends StatelessWidget {
       //   title: Text('Browser'),
       // ),
       builder: (context, viewModel, child) => Scaffold(
-        body: WillPopScope(
-          onWillPop: () async {
-            if (await viewModel.controller!.canGoBack()) {
-              await viewModel.controller!.goBack();
-            } else {
-              viewModel.goBack();
-            }
-            return false;
-          },
-          child: WebView(
-            initialUrl: url,
-            userAgent: "random",
-            javascriptMode: JavascriptMode.unrestricted,
-            onWebViewCreated: viewModel.setController,
+        body: SafeArea(
+          child: WillPopScope(
+            onWillPop: () async {
+              if (await viewModel.controller!.canGoBack()) {
+                await viewModel.controller!.goBack();
+              } else {
+                viewModel.goBack();
+              }
+              return false;
+            },
+            child: WebView(
+              initialUrl: url,
+              userAgent: "random",
+              javascriptMode: JavascriptMode.unrestricted,
+              onWebViewCreated: viewModel.setController,
+            ),
           ),
         ),
       ),

--- a/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
+++ b/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
@@ -14,124 +14,126 @@ class DrawerWidgetView extends StatelessWidget {
       viewModelBuilder: () => DrawerWidgtetViewModel(),
       onModelReady: (model) => model.init(),
       builder: (context, model, child) => Drawer(
-        child: SingleChildScrollView(
-          child: Column(
-            children: [
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Column(
-                    children: const [
-                      Padding(
-                        padding: EdgeInsets.all(25),
-                        child: Text(
-                          'MENU',
-                          style: TextStyle(
-                            fontWeight: FontWeight.bold,
-                            color: Color(0xFF0a0a23),
-                            fontSize: 24,
+        child: SafeArea(
+          child: SingleChildScrollView(
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Column(
+                      children: const [
+                        Padding(
+                          padding: EdgeInsets.all(25),
+                          child: Text(
+                            'MENU',
+                            style: TextStyle(
+                              fontWeight: FontWeight.bold,
+                              color: Color(0xFF0a0a23),
+                              fontSize: 24,
+                            ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                ],
-              ),
-              Row(
-                children: [
-                  Expanded(
-                    child: navButtonWidget(
-                        'NEWS',
-                        '',
-                        const Icon(
-                          Icons.article,
-                          size: 70,
-                        ),
-                        false,
-                        model,
-                        context),
-                  ),
-                  model.inDevelopmentMode || model.showForum
-                      ? Expanded(
-                          child: navButtonWidget(
-                              'FORUM',
-                              '',
-                              const Icon(
-                                Icons.forum_outlined,
-                                size: 70,
-                              ),
-                              false,
-                              model,
-                              context),
-                        )
-                      : Expanded(
-                          child: navButtonWidget(
-                              'LEARN',
-                              'https://www.freecodecamp.org/learn/',
-                              const Icon(
-                                Icons.local_fire_department_sharp,
-                                size: 70,
-                              ),
-                              true,
-                              model,
-                              context),
-                        )
-                ],
-              ),
-              Row(
-                children: [
-                  Expanded(
+                      ],
+                    ),
+                  ],
+                ),
+                Row(
+                  children: [
+                    Expanded(
                       child: navButtonWidget(
-                          'PODCAST',
+                          'NEWS',
                           '',
                           const Icon(
-                            Icons.podcasts_outlined,
+                            Icons.article,
                             size: 70,
                           ),
                           false,
                           model,
-                          context)),
-                  Expanded(
+                          context),
+                    ),
+                    model.inDevelopmentMode || model.showForum
+                        ? Expanded(
+                            child: navButtonWidget(
+                                'FORUM',
+                                '',
+                                const Icon(
+                                  Icons.forum_outlined,
+                                  size: 70,
+                                ),
+                                false,
+                                model,
+                                context),
+                          )
+                        : Expanded(
+                            child: navButtonWidget(
+                                'LEARN',
+                                'https://www.freecodecamp.org/learn/',
+                                const Icon(
+                                  Icons.local_fire_department_sharp,
+                                  size: 70,
+                                ),
+                                true,
+                                model,
+                                context),
+                          )
+                  ],
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                        child: navButtonWidget(
+                            'PODCAST',
+                            '',
+                            const Icon(
+                              Icons.podcasts_outlined,
+                              size: 70,
+                            ),
+                            false,
+                            model,
+                            context)),
+                    Expanded(
+                        child: navButtonWidget(
+                            'RADIO',
+                            'https://coderadio.freecodecamp.org/',
+                            const Icon(
+                              Icons.radio,
+                              size: 70,
+                            ),
+                            true,
+                            model,
+                            context)),
+                  ],
+                ),
+                Row(
+                  children: [
+                    Expanded(
+                        child: navButtonWidget(
+                            'DONATE',
+                            'https://www.freecodecamp.org/donate/',
+                            const Icon(
+                              Icons.favorite,
+                              size: 70,
+                            ),
+                            true,
+                            model,
+                            context)),
+                    model.inDevelopmentMode ? Expanded(
                       child: navButtonWidget(
-                          'RADIO',
-                          'https://coderadio.freecodecamp.org/',
+                          'SETTINGS',
+                          'https://www.google.com/',
                           const Icon(
-                            Icons.radio,
+                            Icons.settings,
                             size: 70,
                           ),
-                          true,
+                          false,
                           model,
-                          context)),
-                ],
-              ),
-              Row(
-                children: [
-                  Expanded(
-                      child: navButtonWidget(
-                          'DONATE',
-                          'https://www.freecodecamp.org/donate/',
-                          const Icon(
-                            Icons.favorite,
-                            size: 70,
-                          ),
-                          true,
-                          model,
-                          context)),
-                  model.inDevelopmentMode ? Expanded(
-                    child: navButtonWidget(
-                        'SETTINGS',
-                        'https://www.google.com/',
-                        const Icon(
-                          Icons.settings,
-                          size: 70,
-                        ),
-                        false,
-                        model,
-                        context),
-                  ) : Container(),
-                ],
-              ),
-            ],
+                          context),
+                    ) : Container(),
+                  ],
+                ),
+              ],
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a descriptive title (not a vague title like `Update index.md`)

Displays gets cut if the phone is having a notch or is having a punch hole camera on menu screen & WebView screen. Issue fixed with SafeArea Widget.

![Screenshot_2021-12-12-15-43-58-30_5f759941e40c3b4ea769d2ffa19638e0](https://user-images.githubusercontent.com/53489549/145708527-f3bac8e1-6a5c-4b14-b67f-2f174e49168d.jpg)
![Screenshot_2021-12-12-15-43-50-99_5f759941e40c3b4ea769d2ffa19638e0](https://user-images.githubusercontent.com/53489549/145708532-a79060d0-733d-4d04-bd20-aac4434508d7.jpg)

