### PR TITLE
fix: update sample env with news key

### DIFF
--- a/sample.env
+++ b/sample.env
@@ -1,4 +1,4 @@
-NEWSKEY=
+NEWSKEY=6f0e520f2469dc3b8162bfb7df
 NEWSURL=https://www.freecodecamp.org/news/ghost/api/v3/content/posts/?key=
 ALGOLIAAPPID=
 ALGOLIAKEY=


### PR DESCRIPTION
the news key is save for everyone to use as stated in the Ghost API:

Content API keys are provided via a query parameter in the url. These keys are safe for use in browsers and other insecure environments, as they only ever provide access to public data. Sites in private mode should consider where they share any keys they create.

