### PR TITLE
UI Change to the side drawer 

### DIFF
--- a/lib/ui/views/home/home_view.dart
+++ b/lib/ui/views/home/home_view.dart
@@ -30,10 +30,7 @@ class HomeView extends StatelessWidget {
           title: titles.elementAt(viewModel.index),
           centerTitle: true,
         ),
-        drawer: SizedBox(
-          width: MediaQuery.of(context).size.width,
-          child: const DrawerWidgetView(),
-        ),
+        drawer: const DrawerWidgetView(),
         body: views.elementAt(viewModel.index),
         bottomNavigationBar: BottomNavigationBar(
           backgroundColor: const Color(0xFF0a0a23),

--- a/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
+++ b/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
@@ -9,132 +9,108 @@ class DrawerWidgetView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    const iconsize = 44.0;
     return ViewModelBuilder<DrawerWidgtetViewModel>.reactive(
       viewModelBuilder: () => DrawerWidgtetViewModel(),
       onModelReady: (model) => model.init(),
       builder: (context, model, child) => Drawer(
-        child: SafeArea(
-          child: SingleChildScrollView(
-            child: Column(
-              children: [
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.center,
+        child: Container(
+          color: const Color(0xFF0a0a23),
+          width: MediaQuery.of(context).size.width * 0.8,
+          child: ListView(
+            children: [
+              DrawerHeader(
+                child: Column(
                   children: [
-                    Column(
-                      children: const [
-                        Padding(
-                          padding: EdgeInsets.all(25),
-                          child: Text(
-                            'MENU',
-                            style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Color(0xFF0a0a23),
-                              fontSize: 24,
-                            ),
-                          ),
-                        ),
-                      ],
+                    Image.asset(
+                      'assets/images/app-logo.png',
+                      width: iconsize * 2,
+                      height: iconsize * 2,
+                    ),
+                    const Text(
+                      'Menu',
+                      style: TextStyle(
+                        fontSize: 24,
+                        color: Colors.white,
+                      ),
                     ),
                   ],
                 ),
-                Row(
-                  children: [
-                    Expanded(
-                      child: navButtonWidget(
-                          'NEWS',
-                          '',
-                          const Icon(
-                            Icons.article,
-                            size: 70,
-                          ),
-                          false,
-                          model,
-                          context),
-                    ),
-                    model.inDevelopmentMode || model.showForum
-                        ? Expanded(
-                            child: navButtonWidget(
-                                'FORUM',
-                                '',
-                                const Icon(
-                                  Icons.forum_outlined,
-                                  size: 70,
-                                ),
-                                false,
-                                model,
-                                context),
-                          )
-                        : Expanded(
-                            child: navButtonWidget(
-                                'LEARN',
-                                'https://www.freecodecamp.org/learn/',
-                                const Icon(
-                                  Icons.local_fire_department_sharp,
-                                  size: 70,
-                                ),
-                                true,
-                                model,
-                                context),
-                          )
-                  ],
-                ),
-                Row(
-                  children: [
-                    Expanded(
-                        child: navButtonWidget(
-                            'PODCAST',
-                            '',
-                            const Icon(
-                              Icons.podcasts_outlined,
-                              size: 70,
-                            ),
-                            false,
-                            model,
-                            context)),
-                    Expanded(
-                        child: navButtonWidget(
-                            'RADIO',
-                            'https://coderadio.freecodecamp.org/',
-                            const Icon(
-                              Icons.radio,
-                              size: 70,
-                            ),
-                            true,
-                            model,
-                            context)),
-                  ],
-                ),
-                Row(
-                  children: [
-                    Expanded(
-                        child: navButtonWidget(
-                            'DONATE',
-                            'https://www.freecodecamp.org/donate/',
-                            const Icon(
-                              Icons.favorite,
-                              size: 70,
-                            ),
-                            true,
-                            model,
-                            context)),
-                    model.inDevelopmentMode
-                        ? Expanded(
-                            child: navButtonWidget(
-                                'SETTINGS',
-                                'https://www.google.com/',
-                                const Icon(
-                                  Icons.settings,
-                                  size: 70,
-                                ),
-                                false,
-                                model,
-                                context),
-                          )
-                        : Container(),
-                  ],
-                ),
-              ],
-            ),
+              ),
+              navButtonWidget(
+                  'News',
+                  '',
+                  const Icon(
+                    Icons.article,
+                    size: iconsize,
+                  ),
+                  false,
+                  model,
+                  context),
+              model.inDevelopmentMode || model.showForum
+                  ? navButtonWidget(
+                      'Forum',
+                      '',
+                      const Icon(
+                        Icons.forum_outlined,
+                        size: iconsize,
+                      ),
+                      false,
+                      model,
+                      context)
+                  : navButtonWidget(
+                      'Learn',
+                      'https://www.freecodecamp.org/learn/',
+                      const Icon(
+                        Icons.local_fire_department_sharp,
+                        size: iconsize,
+                      ),
+                      true,
+                      model,
+                      context),
+              navButtonWidget(
+                  'Podcast',
+                  '',
+                  const Icon(
+                    Icons.podcasts_outlined,
+                    size: iconsize,
+                  ),
+                  false,
+                  model,
+                  context),
+              navButtonWidget(
+                  'Radio',
+                  'https://coderadio.freecodecamp.org/',
+                  const Icon(
+                    Icons.radio,
+                    size: iconsize,
+                  ),
+                  true,
+                  model,
+                  context),
+              navButtonWidget(
+                  'Donate',
+                  'https://www.freecodecamp.org/donate/',
+                  const Icon(
+                    Icons.favorite,
+                    size: iconsize,
+                  ),
+                  true,
+                  model,
+                  context),
+              model.inDevelopmentMode
+                  ? navButtonWidget(
+                      'Settings',
+                      'https://www.google.com/',
+                      const Icon(
+                        Icons.settings,
+                        size: iconsize,
+                      ),
+                      false,
+                      model,
+                      context)
+                  : const SizedBox(),
+            ],
           ),
         ),
       ),
@@ -142,55 +118,29 @@ class DrawerWidgetView extends StatelessWidget {
   }
 }
 
-InkWell navButtonWidget(String text, url, Icon icon, bool isWebComponent,
+Widget navButtonWidget(String text, url, Icon icon, bool isWebComponent,
     DrawerWidgtetViewModel model, context) {
-  return InkWell(
-    onTap: () {
-      if (isWebComponent) {
-        model.goToBrowser(url);
-      } else {
-        model.navNonWebComponent(text, context);
-      }
-    },
-    child: Padding(
-      padding: const EdgeInsets.all(20.0),
-      child: Container(
-        width: 160,
-        decoration: BoxDecoration(
-          color: const Color.fromRGBO(0xD0, 0xD0, 0xD5, 1),
-          border: Border.all(color: Colors.black, width: 3),
-        ),
-        child: Column(
-          children: [
-            Row(
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: icon,
-                  ),
-                )
-              ],
-            ),
-            Row(
-              children: [
-                Expanded(
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Text(
-                      text,
-                      style: const TextStyle(
-                        fontSize: 18,
-                        fontWeight: FontWeight.w600,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
+  return Padding(
+    padding: const EdgeInsets.all(10.0),
+    child: ListTile(
+      onTap: () {
+        if (isWebComponent) {
+          model.goToBrowser(url);
+        } else {
+          model.navNonWebComponent(text, context);
+        }
+      },
+      leading: Icon(
+        icon.icon,
+        color: Colors.white,
+      ),
+      title: Text(
+        text,
+        style: const TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.w400,
+            color: Colors.white,
+            letterSpacing: 0.5),
       ),
     ),
   );


### PR DESCRIPTION
The UI of the side drawer has been improved to match the rest of the app
The Background Matches the color of the app now.
The Side Drawer doesn't take up the entire width of the screen like before
How it looks now:
(https://user-images.githubusercontent.com/55798225/145781702-d8ff325e-35d8-4296-898c-a236eff997b8.jpg)

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our te
![sidedrawer
am takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #108 

<!-- Feel free to add any additional description of changes below this line -->
