### PR TITLE
moved variables outside build() method

### DIFF
--- a/mobile-app/lib/ui/views/home/home_view.dart
+++ b/mobile-app/lib/ui/views/home/home_view.dart
@@ -10,19 +10,21 @@ import 'home_viemmodel.dart';
 class HomeView extends StatelessWidget {
   const HomeView({Key? key}) : super(key: key);
 
+  static const titles = <Widget>[
+    Text('BOOKMARKED ARTICLES'),
+    Text('NEWSFEED'),
+    Text('SEARCH ARTICLES')
+  ];
+
+  static const views = <Widget>[
+    NewsBookmarkFeedView(),
+    NewsFeedView(),
+    NewsSearchView()
+    //const ArticleSearch()
+  ];
+
   @override
   Widget build(BuildContext context) {
-    List<dynamic> views = <dynamic>[
-      const NewsBookmarkFeedView(),
-      const NewsFeedView(),
-      const NewsSearchView()
-      //const ArticleSearch()
-    ];
-    List<Widget> titles = <Widget>[
-      const Text('BOOKMARKED ARTICLES'),
-      const Text('NEWSFEED'),
-      const Text('SEARCH ARTICLES')
-    ];
     return ViewModelBuilder<HomeViewModel>.reactive(
       builder: (context, viewModel, child) => Scaffold(
         appBar: AppBar(
@@ -34,30 +36,36 @@ class HomeView extends StatelessWidget {
           width: MediaQuery.of(context).size.width,
           child: const DrawerWidgetView(),
         ),
-        body: views.elementAt(viewModel.index),
+        body: IndexedStack(
+          index: viewModel.index,
+          children: views,
+        ),
         bottomNavigationBar: BottomNavigationBar(
           backgroundColor: const Color(0xFF0a0a23),
           unselectedItemColor: Colors.white,
           selectedItemColor: const Color.fromRGBO(0x99, 0xc9, 0xff, 1),
           items: const <BottomNavigationBarItem>[
             BottomNavigationBarItem(
-                icon: Icon(
-                  Icons.bookmark_outline_sharp,
-                  color: Colors.white,
-                ),
-                label: 'Bookmarks'),
+              icon: Icon(
+                Icons.bookmark_outline_sharp,
+                color: Colors.white,
+              ),
+              label: 'Bookmarks',
+            ),
             BottomNavigationBarItem(
-                icon: Icon(
-                  Icons.article_sharp,
-                  color: Colors.white,
-                ),
-                label: 'Articles'),
+              icon: Icon(
+                Icons.article_sharp,
+                color: Colors.white,
+              ),
+              label: 'Articles',
+            ),
             BottomNavigationBarItem(
-                icon: Icon(
-                  Icons.search_sharp,
-                  color: Colors.white,
-                ),
-                label: 'Search')
+              icon: Icon(
+                Icons.search_sharp,
+                color: Colors.white,
+              ),
+              label: 'Search',
+            )
           ],
           currentIndex: viewModel.index,
           onTap: viewModel.onTapped,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

### variable -
Having the `views` and `titles` variables inside the `build()` method is a side effect and causes unnecessary variable calls.

I have moved the views and titles variables outside the `build()` method, and made them static const.

### IndexedStack -
I have warped the `views` Widgets inside the `IndexedStack` Widget which caches the children widgets state and prevents loading Widget in every time the BottomNavigationBar changes.

<!-- Feel free to add any additional description of changes below this line -->
