### PR TITLE
feat: Updated dependencies for successful build on Flutter 2.8 

### DIFF
--- a/mobile-app/lib/ui/views/news/news-feed/news_feed_viewmodel.dart
+++ b/mobile-app/lib/ui/views/news/news-feed/news_feed_viewmodel.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as dev;
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:freecodecamp/app/app.locator.dart';
 import 'package:freecodecamp/app/app.router.dart';

--- a/mobile-app/pubspec.lock
+++ b/mobile-app/pubspec.lock
@@ -42,7 +42,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   audio_service:
     dependency: transitive
     description:
@@ -140,7 +140,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: chewie
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.1.0"
   chewie_audio:
     dependency: transitive
     description:
@@ -343,7 +343,7 @@ packages:
       name: flutter_html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.1"
   flutter_inappwebview:
     dependency: transitive
     description:
@@ -392,7 +392,7 @@ packages:
       name: flutter_math_fork
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.3+1"
+    version: "0.5.0"
   flutter_page_indicator:
     dependency: transitive
     description:
@@ -427,7 +427,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.22.0"
+    version: "0.23.0+1"
   flutter_swiper:
     dependency: "direct main"
     description:
@@ -649,7 +649,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: "direct overridden"
     description:
@@ -796,7 +796,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.2"
   pub_semver:
     dependency: transitive
     description:
@@ -955,7 +955,7 @@ packages:
       name: stacked
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.7"
+    version: "2.2.8"
   stacked_generator:
     dependency: "direct dev"
     description:
@@ -1011,7 +1011,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timezone:
     dependency: transitive
     description:
@@ -1116,7 +1116,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   video_player:
     dependency: transitive
     description:

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -6,14 +6,14 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 dependencies:
   flutter_font_awesome_web_names:
-   git:
-     url: https://github.com/Mythar/flutter_font_awesome_web_names
-     ref: master
+    git:
+      url: https://github.com/Mythar/flutter_font_awesome_web_names
+      ref: master
   cupertino_icons: ^1.0.3
   flutter:
     sdk: flutter
   flutter_dotenv: ^5.0.2
-  flutter_html: ^2.1.2
+  flutter_html: ^2.2.1
   flutter_lints: ^1.0.4
   flutter_slidable: ^0.6.0
   flip_card: ^0.5.0
@@ -37,12 +37,12 @@ dependencies:
   just_audio_background: ^0.0.1-beta.1
   hexcolor: ^2.0.5
   flutter_syntax_view:
-   git:
-     url: https://github.com/Sembauke/flutter_syntax_view
-     ref: master
+    git:
+      url: https://github.com/Sembauke/flutter_syntax_view
+      ref: master
   jiffy: ^5.0.0
   share: ^2.0.4
-  flutter_svg: ^0.22.0
+  flutter_svg: ^0.23.0+1
   shared_preferences: ^2.0.7
   font_awesome_flutter: ^9.1.0
   html: ^0.15.0


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #182 

<!-- Feel free to add any additional description of changes below this line -->
This project was failing to build on Flutter 2.8 . On following the dependency tree, the following solution worked
- flutter_html - ^2.1.2 to ^2.2.1
- flutter_svg - ^0.22.0 to ^0.23.0+1

flutter svg has a more latest version available but it is not supported by flutter_html for now.

Also in `news_feed_viewmodel.dart` there was an import missing because of which the build was failing. I have added the `import 'dart:developer' as dev` .