### PR TITLE
chore(renovate): use common global config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,3 @@
 {
-  "extends": [
-    "config:base"
-  ]
+ "extends": ["github>freecodecamp/renovate-config"]
 }


### PR DESCRIPTION
Uses the global config (automated updates received ~~and merged~~ on weekends 🎉, dashboard issue, less noise overall).

If confident about merges (usually means good tests / linting), let me know to include the approval bots in the config and we can enable skipping approvals by humans. Else this can go in as-is regardless for the weekend-ly updates.