### PR TITLE
fix(api): remove unused build command

### DIFF
--- a/mobile-api/package.json
+++ b/mobile-api/package.json
@@ -9,7 +9,7 @@
     "npm": ">=8"
   },
   "scripts": {
-    "build": "tsc && npm run pre:build:schema",
+    "build": "tsc",
     "dev": "nodemon src/index.ts",
     "lint": "npm run lint:prettier && npm run lint:src",
     "lint:src": "eslint --max-warnings 0 .",


### PR DESCRIPTION
Removes the `pre:build:schema` from the api build command.