### PR TITLE
fix: log in flow

### DIFF
--- a/mobile-app/lib/service/authentication_service.dart
+++ b/mobile-app/lib/service/authentication_service.dart
@@ -125,18 +125,13 @@ class AuthenticationService {
   }
 
   Future<void> login(BuildContext context) async {
-    bool authRes = await extractCookies();
-
-    if (!authRes) {
-      var navRes = await Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => const LoginWebView(),
-        ),
-      );
-      log('AUTH SERVICE NAV RES: $navRes');
-    }
-    log('AUTH SERVICE AUTH RES: $authRes');
+    var navRes = await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const LoginWebView(),
+      ),
+    );
+    log('AUTH SERVICE NAV RES: $navRes');
     await writeTokensToStorage();
     await fetchUser();
   }

--- a/mobile-app/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
+++ b/mobile-app/lib/ui/widgets/drawer_widget/drawer_widget_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:freecodecamp/models/main/user_model.dart';
+import 'package:freecodecamp/service/test_service.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_button.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_web_buttton.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_viewmodel.dart';
@@ -105,8 +106,10 @@ class DrawerWidgetView extends StatelessWidget {
                         textColor: model.loggedIn
                             ? const Color.fromARGB(255, 230, 59, 59)
                             : null,
-                        route: () {
-                          model.loginSnack();
+                        route: () async {
+                          await TestService().developmentMode()
+                              ? model.handleAuth(context)
+                              : model.loginSnack();
                         })
                   ],
                 ),

--- a/mobile-app/lib/ui/widgets/login_webview_widget/login_webview_view.dart
+++ b/mobile-app/lib/ui/widgets/login_webview_widget/login_webview_view.dart
@@ -25,8 +25,7 @@ class LoginWebView extends StatelessWidget {
           onWebViewCreated: (controller) async {
             model.webController = controller;
             await controller.clearCache();
-            // If a cookie error happens, we can consider using the below code
-            // await CookieManager().clearCookies();
+            await CookieManager().clearCookies();
           },
           navigationDelegate: (action) async {
             log('NAVIGATION DELEGATE: ${action.url}');


### PR DESCRIPTION
When I was making the log in flow I had set it up in such a way that the `WebView` cookies would be persisted so this allow the user to login faster after their first login(by fetching the same cookies used in the previous successful login). But I didn't think of the case wherein a different user might want to login in the same device. This PR fixes that situation.

Thanks to @ojeytonwilliams for pointing this out.