### PR TITLE
chore(api): create api commands at root level

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -31,9 +31,7 @@ jobs:
       - name: Build site
         env:
           NODE_ENV: production
-        run: |
-          cd mobile-api
-          npm run build
+        run: npm run build:api
 
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v1

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "backend-api"
   ],
   "scripts": {
+    "build:api": "cd mobile-api && npm run build",
     "postinstall": "cd mobile-app && flutter pub get",
     "develop": "npm-run-all flutter:build-runner -p develop:*",
     "develop:api": "cd mobile-api && npm run dev",


### PR DESCRIPTION
I've created a build command for the API at the root `package.json`.

@raisedadead is there any other command you need to be created at the root `package.json`?