### PR TITLE
fix: updated the UI of the progress bar in podcast

### DIFF
--- a/mobile-app/lib/ui/widgets/podcast_widgets/podcast_progressbar_widget.dart
+++ b/mobile-app/lib/ui/widgets/podcast_widgets/podcast_progressbar_widget.dart
@@ -69,11 +69,11 @@ class PodcastProgressBarState extends State<PodcastProgressBar> {
       double newWidth =
           (value.inSeconds / widget.duration.inSeconds) * maxBarWidth;
 
-      bool shouldSetNewWidth = newWidth + widget.ball < maxBarWidth;
-      if (newWidth < widget.ball / 4) {
-        widget._barWidth = widget.ball / 4;
+      bool shouldSetNewWidth = newWidth*0.95 + widget.ball < maxBarWidth;
+      if (newWidth < widget.ball / 12) {
+        widget._barWidth = widget.ball / 12;
       } else if (shouldSetNewWidth) {
-        widget._barWidth = newWidth;
+        widget._barWidth = newWidth*0.95;
       }
 
       if (value.isNegative || newWidth.isNegative) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #451

<!-- Feel free to add any additional description of changes below this line -->
Screenshot of the changed code is attached below:
![Screenshot from 2022-08-04 23-58-47](https://user-images.githubusercontent.com/47777599/182925499-364da766-d5f0-4d74-b22f-408192f69bd2.png)

**Problems:** 
- Basically in the previous code the ball only moves after 42 seconds.
-  The ending of the podcast and the progress bar was not in sync (either the bar stops early, or there is still left of the podcast)

**Solution:** 
- By dividing with larger number the seconds will be reduced. I have made it to 14 seconds.
- Calculated the amount of newWidth and multiplied with 0.95

