### PR TITLE
fix: hide appbar when hint or pass panel is open

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge_editor/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge_editor/challenge_view.dart
@@ -287,10 +287,12 @@ class ChallengeView extends StatelessWidget {
                       model.setPanelType = PanelType.hint;
                       model.setHint = test.instruction;
                       model.setShowPanel = true;
+                      model.setHideAppBar = true;
                     } else {
                       model.setPanelType = PanelType.pass;
                       model.setCompletedChallenge = true;
                       model.setShowPanel = true;
+                      model.setHideAppBar = true;
                     }
                   },
                 )


### PR DESCRIPTION
The appbar shows up when either the hint panel or pass panel is opened. This PR fixes that and hides it when a panel is open.