### PR TITLE
fix: article tags

### DIFF
--- a/mobile-app/lib/ui/widgets/tag_widget.dart
+++ b/mobile-app/lib/ui/widgets/tag_widget.dart
@@ -53,6 +53,8 @@ class _TagButtonState extends State<TagButton>
           );
         },
         child: Container(
+          constraints: BoxConstraints(
+              maxWidth: MediaQuery.of(context).size.width * 0.45),
           decoration: ShapeDecoration(
             color: _tagColor,
             shape: const StadiumBorder(),
@@ -62,11 +64,16 @@ class _TagButtonState extends State<TagButton>
               vertical: 4,
               horizontal: 8,
             ),
-            child: Text(
-              '#${widget.tagName}',
-              style: const TextStyle(
-                fontSize: 16,
-                color: Colors.black,
+            child: Tooltip(
+              message: '#${widget.tagName}',
+              child: Text(
+                '#${widget.tagName}',
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: Colors.black,
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
The article tags wil now truncate if they are to big.

When holding the article tag a tooltip will show up with the full article tag name. 

This pr prevent tags to go on more than 2 lines or having an inconsistent height.