### PR TITLE
fix: return from read files if API keys are not present

### DIFF
--- a/mobile-app/lib/ui/views/news/news-feed/news_feed_view.dart
+++ b/mobile-app/lib/ui/views/news/news-feed/news_feed_view.dart
@@ -193,7 +193,7 @@ class NewsFeedView extends StatelessWidget {
                               fit: BoxFit.cover,
                             )
                           : CachedNetworkImage(
-                              imageUrl: article.profileImage as String,
+                              imageUrl: article.profileImage ?? '',
                               imageBuilder: (context, imageProvider) =>
                                   Container(
                                 decoration: BoxDecoration(

--- a/mobile-app/lib/ui/views/news/news-feed/news_feed_viewmodel.dart
+++ b/mobile-app/lib/ui/views/news/news-feed/news_feed_viewmodel.dart
@@ -56,6 +56,7 @@ class NewsFeedModel extends BaseViewModel {
   }
 
   Future<List<Article>> fetchArticles(String slug, String author) async {
+    if (await _testService.developmentMode()) return readFromFiles();
     await dotenv.load(fileName: '.env');
 
     String hasSlug = slug != '' ? '&filter=tag:$slug' : '';


### PR DESCRIPTION
It would first check if dev-mode is set too true or false. Then it would see that it is set to false. Tries to load articles instead without the API keys. Next it would set dev-mode to true and fetch the articles from the example.

Now it would do the same, but only it will first check if dev-mode is set to true.


