### PR TITLE
fix: make app file debugable

### DIFF
--- a/mobile-app/analysis_options.yaml
+++ b/mobile-app/analysis_options.yaml
@@ -1,7 +1,12 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-  exclude: [lib/app/**, temp/**]
+  exclude: [
+   temp/**,
+   lib/app/app.locator.dart,
+   lib/app/app.logger.dart,
+   lib/app/app.router.dart
+   ]
   errors:
     todo: warning
 linter:


### PR DESCRIPTION
This makes it easier to find path errors in the `app.dart` file when adding or renaming routes.