### PR TITLE
chore(api): downgrade node image to LTS version

### DIFF
--- a/mobile-api/Dockerfile
+++ b/mobile-api/Dockerfile
@@ -1,15 +1,15 @@
-FROM node:19-alpine AS builder
+FROM node:18-alpine AS builder
 WORKDIR /build
 COPY . .
 RUN npm ci
 RUN npm run build
 
-FROM node:19-alpine AS dependencies
+FROM node:18-alpine AS dependencies
 WORKDIR /build
 COPY package-lock.json package.json ./
 RUN npm ci --production
 
-FROM node:19-alpine
+FROM node:18-alpine
 WORKDIR /api
 COPY --from=builder /build/package.json /build/package-lock.json ./
 COPY --from=builder /build/prod/  ./prod/


### PR DESCRIPTION
Renovate upgraded the node docker image from 16 to 19 and 19 is not the latest LTS version. This PR downgrades it v18 which is the latest LTS version of Node.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
