### PR TITLE
Preview feature made unavailable for JS challenges

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -374,6 +374,10 @@ class ChallengeView extends StatelessWidget {
                     : Colors.white,
               ),
               onPressed: () async {
+                if(challenge.challengeType == 1){
+                  model.previewNotAvailableSnackbar();
+                  return;
+                }
                 ChallengeFile currFile = model.currentFile(challenge);
 
                 String currText = await model.fileService.getExactFileFromCache(

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -257,6 +257,10 @@ class ChallengeViewModel extends BaseViewModel {
     );
   }
 
+  void previewNotAvailableSnackbar() {
+    snackbar.showSnackbar(
+        message: 'Preview not available for this challenge type.');
+  }
   // This prevents the user from requesting the challenge more than once
   // when swichting between preview and the challenge.
 
@@ -325,7 +329,7 @@ class ChallengeViewModel extends BaseViewModel {
     String viewPort = '''<meta content="width=device-width,
          initial-scale=1.0, maximum-scale=1.0,
          user-scalable=no" name="viewport">
-         </meta>''';
+         <meta>''';
 
     dom.Document viewPortParsed = parse(viewPort);
     dom.Node meta = viewPortParsed.getElementsByTagName('META')[0];


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #567

<!-- Feel free to add any additional description of changes below this line -->

As far as I understood, every challenge has a type. I could only find challenges of two types. 0 and 1. So challenge with 0 were of HTML, CSS and challenge of type 1 were js, DSA, euler project.

If my understanding is correct, then the preview function won't work for any challenge type that doesn't deal with UI and hence I coded according to that thought process. 

Also, I have changed the <meta> thing because it was giving a warning when I was trying to push the code.

Please review the PR and provide valuable feedback. If you find the implementation to be correct, Please merge the PR. If I am thinking in the wrong direction, please tell me the exact requirement so that I can fix it
