### PR TITLE
fix: title widget in PodcastListView

### DIFF
--- a/mobile-app/lib/ui/views/podcast/podcast-list/podcast_list_view.dart
+++ b/mobile-app/lib/ui/views/podcast/podcast-list/podcast_list_view.dart
@@ -20,8 +20,8 @@ class PodcastListView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     List titles = [
-      context.t.podcasts_title,
-      context.t.podcast_download_title,
+      Text(context.t.podcasts_title),
+      Text(context.t.podcast_download_title),
     ];
 
     return ViewModelBuilder<PodcastListViewModel>.reactive(


### PR DESCRIPTION

![Screenshot_2023-08-21-19-08-52-13_5f759941e40c3b4ea769d2ffa19638e0](https://github.com/freeCodeCamp/mobile/assets/92450890/96f09658-d282-4974-bb04-1d26d886c627)
This pull request addresses the issue with the title display in the `PodcastListView` widget.

Fixes #1094 

**Issue**

Previously, there was an issue where the title was not being displayed correctly in the `PodcastListView` widget. The title was expected to be a widget but was being treated as a string.

**Solution**

I resolved this issue by encapsulating the title string in a `Text` widget in the `PodcastListView` widget. This ensures that the title is displayed correctly as a widget, resolving the bug.

**Testing**

I tested the solution by running the app and navigating to the `PodcastListView` screen. The title is now displayed correctly without any errors.




