### PR TITLE
feat(actions): use DOCR registry instead of ACR

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -37,10 +37,14 @@ jobs:
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v1
 
+      - name: Create a tagname
+        id: tagname
+        run: |
+          echo "tagname=$(git rev-parse --short HEAD)-$(date +%Y%m%d)-$(date +%H%M)" >> $GITHUB_ENV
+
       - name: Build & Tag Images
         run: |
           cd mobile-api
-          tagname=$(git rev-parse --short HEAD)-$(date +%Y%m%d)-$(date +%H%M)
           docker build . \
           --tag registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:$tagname \
           --tag registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:latest \

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -3,6 +3,7 @@ name: Build and Deploy API
 on:
   workflow_dispatch:
 
+
 jobs:
   build:
     name: Build
@@ -11,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x]
-        site_tlds: [dev, org]
+        node-version: [ 18.x ]
+        site_tlds: [ dev, org ]
 
     steps:
       - name: Checkout source code
@@ -36,19 +37,24 @@ jobs:
       # - name: Set up Docker Buildx
       #   uses: docker/setup-buildx-action@v1
 
-      - name: Docker login to Azure Container Registry
-        uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 # v1
-        with:
-          login-server: ${{ secrets.ACR_NAME }}.azurecr.io
-          username: ${{ secrets.ACR_USERNAME }}
-          password: ${{ secrets.ACR_PASSWORD }}
-
-      - name: Build & Push Docker Images
+      - name: Build & Tag Images
         run: |
           cd mobile-api
           tagname=$(git rev-parse --short HEAD)-$(date +%Y%m%d)-$(date +%H%M)
           docker build . \
-          --tag ${{ secrets.ACR_NAME }}.azurecr.io/${{ matrix.site_tlds }}/mobile-api:$tagname \
-          --tag ${{ secrets.ACR_NAME }}.azurecr.io/${{ matrix.site_tlds }}/mobile-api:latest \
+          --tag registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:$tagname \
+          --tag registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:latest \
           --file Dockerfile
-          docker push --all-tags ${{ secrets.ACR_NAME }}.azurecr.io/${{ matrix.site_tlds }}/mobile-api
+
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Log in to DigitalOcean Container Registry with short-lived credentials
+        run: doctl registry login --expiry-seconds 1200
+
+      - name: Push image to DigitalOcean Container Registry
+        run: |
+          docker push registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:$tagname
+          docker push registry.digitalocean.com/${{ secrets.DOCR_NAME }}/${{ matrix.site_tlds }}/mobile-api:latest


### PR DESCRIPTION
Swapping the Azure Container Registry with DigitalOcean Container Registry for the low-deployment.

Note that while it is not evident in the PR, the API deployments will also move from Azure Container Instances to DigitalOcean's Apps - deploying the instances from DOCR, with automatic deployments when the image is updated via this GitHub Action.