### PR TITLE
fix: display default banner for articles without banner image

### DIFF
--- a/mobile-app/lib/models/news/tutorial_model.dart
+++ b/mobile-app/lib/models/news/tutorial_model.dart
@@ -4,7 +4,7 @@ import 'package:freecodecamp/ui/widgets/tag_widget.dart';
 class Tutorial {
   final String id;
   final String title;
-  final String featureImage;
+  final String? featureImage;
   final String? profileImage;
   final String authorName;
   final String authorSlug;

--- a/mobile-app/lib/ui/views/news/news-feed/news_feed_view.dart
+++ b/mobile-app/lib/ui/views/news/news-feed/news_feed_view.dart
@@ -141,18 +141,24 @@ class NewsFeedView extends StatelessWidget {
           color: const Color.fromRGBO(0x2A, 0x2A, 0x40, 1),
           child: AspectRatio(
             aspectRatio: 16 / 9,
-            child: CachedNetworkImage(
-              imageUrl: tutorial.featureImage,
-              errorWidget: (context, url, error) => const Icon(Icons.error),
-              imageBuilder: (context, imageProvider) => Container(
-                decoration: BoxDecoration(
-                  image: DecorationImage(
-                    image: imageProvider,
+            child: tutorial.featureImage == null
+                ? Image.asset(
+                    'assets/images/freecodecamp-banner.png',
                     fit: BoxFit.cover,
+                  )
+                : CachedNetworkImage(
+                    imageUrl: tutorial.featureImage!,
+                    errorWidget: (context, url, error) =>
+                        const Icon(Icons.error),
+                    imageBuilder: (context, imageProvider) => Container(
+                      decoration: BoxDecoration(
+                        image: DecorationImage(
+                          image: imageProvider,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
+                    ),
                   ),
-                ),
-              ),
-            ),
           ),
         ),
         Align(

--- a/mobile-app/lib/ui/views/news/news-tutorial/news_tutorial_view.dart
+++ b/mobile-app/lib/ui/views/news/news-tutorial/news_tutorial_view.dart
@@ -19,10 +19,15 @@ class NewsTutorialHeader extends StatelessWidget {
       children: [
         AspectRatio(
           aspectRatio: 16 / 9,
-          child: Image.network(
-            tutorial.featureImage,
-            fit: BoxFit.cover,
-          ),
+          child: tutorial.featureImage == null
+              ? Image.asset(
+                  'assets/images/freecodecamp-banner.png',
+                  fit: BoxFit.cover,
+                )
+              : Image.network(
+                  tutorial.featureImage!,
+                  fit: BoxFit.cover,
+                ),
         ),
         Row(
           children: [

--- a/mobile-app/lib/ui/widgets/tutorial_list_widget.dart
+++ b/mobile-app/lib/ui/widgets/tutorial_list_widget.dart
@@ -149,10 +149,15 @@ class TileLayout extends StatelessWidget {
                 minWidth: imgSize,
                 maxWidth: imgSize,
               ),
-              child: Image.network(
-                tutorial.featureImage,
-                fit: BoxFit.cover,
-              ),
+              child: tutorial.featureImage == null
+                  ? Image.asset(
+                      'assets/images/freecodecamp-banner.png',
+                      fit: BoxFit.cover,
+                    )
+                  : Image.network(
+                      tutorial.featureImage!,
+                      fit: BoxFit.cover,
+                    ),
             ),
             onTap: () {
               widget.navigateToTutorial(tutorial.id, tutorial.title);


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
This [article](https://www.freecodecamp.org/news/want-to-learn-typescript-heres-our-free-22-part-course-21cd9bbb5ef5/) doesn't have a banner image and so it wouldn't load and crash the app.

Crashlytics report - https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/android:org.freecodecamp/issues/c9ec186d68409cc16db6181d93623416?time=last-thirty-days&sessionEventKey=651D016E03210004107F391115692116_1864426950094230251