### PR TITLE
fix: codemagic failing build

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -15,7 +15,7 @@ workflows:
       cancel_previous_builds: true
 
     environment:
-      flutter: 3.13.6
+      flutter: 3.13.7
       xcode: latest
       cocoapods: default
       groups:
@@ -83,7 +83,7 @@ workflows:
       cancel_previous_builds: true
 
     environment:
-      flutter: 3.13.6
+      flutter: 3.13.7
       xcode: latest
       cocoapods: default
       ios_signing:


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
Looking at the hotfix changelog, flutter version 3.13.7 could prevent the recent increase in build time outs in codemagic.