### PR TITLE
fix: OAuth login issues

### DIFF
--- a/mobile-app/lib/service/authentication/authentication_service.dart
+++ b/mobile-app/lib/service/authentication/authentication_service.dart
@@ -14,6 +14,7 @@ import 'package:freecodecamp/models/main/user_model.dart';
 import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/ui/views/auth/privacy_view.dart';
 import 'package:stacked_services/stacked_services.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class AuthenticationService {
   static final AuthenticationService _authenticationService =
@@ -208,9 +209,13 @@ class AuthenticationService {
       await writeTokensToStorage();
       await fetchUser();
     } on DioException catch (err, st) {
+      String supportEmail = Uri.encodeComponent('mobile@feeecodecamp.org');
+      String subject = Uri.encodeComponent('Error logging in to mobile app');
       Navigator.pop(context);
       if (err.response != null) {
-        showDialog(
+        String body = Uri.encodeComponent(
+            'Please email the below error to mobile@freecodecamp.org\n\n${err.response!.data.toString()}\n\n${st.toString()}');
+        await showDialog(
           context: context,
           barrierDismissible: false,
           routeSettings: const RouteSettings(
@@ -222,11 +227,23 @@ class AuthenticationService {
             content: SingleChildScrollView(
               child: SelectionArea(
                 child: Text(
-                  'Please email this error to mobile@freecodecamp.org: \n\n${err.response!.data.toString()}\n\n${st.toString()}',
+                  'Please email the below error to mobile@freecodecamp.org:\n\n${err.response!.data.toString()}\n\n${st.toString()}',
                 ),
               ),
             ),
             actions: [
+              TextButton(
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFF0a0a23),
+                ),
+                onPressed: () async {
+                  logout();
+                  await launchUrl(Uri.parse(
+                      'mailto:$supportEmail?subject=$subject&body=$body'));
+                  Navigator.pop(context);
+                },
+                child: const Text('Email Error'),
+              ),
               TextButton(
                 style: TextButton.styleFrom(
                   backgroundColor: const Color(0xFF0a0a23),
@@ -241,7 +258,9 @@ class AuthenticationService {
           ),
         );
       } else {
-        showDialog(
+        String body = Uri.encodeComponent(
+            'Please email the below error to mobile@freecodecamp.org\n\n${err.toString()}\n\n${st.toString()}');
+        await showDialog(
           context: context,
           barrierDismissible: false,
           routeSettings: const RouteSettings(
@@ -253,11 +272,23 @@ class AuthenticationService {
             content: SingleChildScrollView(
               child: SelectionArea(
                 child: Text(
-                  'Oops! Something went wrong. Please try again in a moment.\n${st.toString()}',
+                  'Please email the below error to mobile@freecodecamp.org:\n\n${err.toString()}\n\n${st.toString()}',
                 ),
               ),
             ),
             actions: [
+              TextButton(
+                style: TextButton.styleFrom(
+                  backgroundColor: const Color(0xFF0a0a23),
+                ),
+                onPressed: () async {
+                  logout();
+                  await launchUrl(Uri.parse(
+                      'mailto:$supportEmail?subject=$subject&body=$body'));
+                  Navigator.pop(context);
+                },
+                child: const Text('Email Error'),
+              ),
               TextButton(
                 style: TextButton.styleFrom(
                   backgroundColor: const Color(0xFF0a0a23),
@@ -272,6 +303,7 @@ class AuthenticationService {
           ),
         );
       }
+      return false;
     }
 
     final user = await userModel;
@@ -302,6 +334,7 @@ class AuthenticationService {
     }
 
     await auth0.credentialsManager.clearCredentials();
+    // ignore: unnecessary_null_comparison
     if (res != null) {
       Navigator.pop(context);
       Navigator.pop(context);

--- a/mobile-app/lib/service/authentication/authentication_service.dart
+++ b/mobile-app/lib/service/authentication/authentication_service.dart
@@ -4,7 +4,6 @@ import 'dart:io';
 
 import 'package:auth0_flutter/auth0_flutter.dart';
 import 'package:dio/dio.dart';
-import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
@@ -209,7 +208,6 @@ class AuthenticationService {
       await writeTokensToStorage();
       await fetchUser();
     } on DioException catch (err, st) {
-      FirebaseCrashlytics.instance.recordError(err, st);
       Navigator.pop(context);
       if (err.response != null) {
         showDialog(
@@ -224,7 +222,7 @@ class AuthenticationService {
             content: SingleChildScrollView(
               child: SelectionArea(
                 child: Text(
-                  '${err.response!.data}\n$st',
+                  'Please email this error to mobile@freecodecamp.org: \n\n${err.response!.data.toString()}\n\n${st.toString()}',
                 ),
               ),
             ),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->

Login error dialogs were not awaited and some crashlytics report seem to say the response schema is different from what we get from the API.

Crashlytics report:
* https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/ios:org.freecodecamp.ios/issues/ac7c7e9f9e7891b0009ed5d6e8df478d?time=last-seven-days&sessionEventKey=6436e301d7ad4fd7bfe1b3e0d4f2803a_1879083395981658281
* https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/android:org.freecodecamp/issues/57fb110671c5bcc8135b4ce6506068e9?time=last-seven-days&sessionEventKey=65523025010A00010917AEB0ACB74BC8_1879396829724126472


I've not used the localisation strings here as I'm hoping with this PR the number of failed logins will reduce. If it goes well then in a future PR, I'll replace them.