### PR TITLE
fix: stop showing cached challenge data

### DIFF
--- a/mobile-app/lib/service/learn/learn_offline_service.dart
+++ b/mobile-app/lib/service/learn/learn_offline_service.dart
@@ -60,7 +60,7 @@ class LearnOfflineService {
     bool hasStoredChallenges = storedChallenges != null;
 
     if (!hasStoredChallenges) {
-      prefs.setStringList('storedChallenges', []);
+      // prefs.setStringList('storedChallenges', []);
     } else {
       List<ChallengeDownload> converted = [];
 
@@ -82,32 +82,41 @@ class LearnOfflineService {
 
   Future<Challenge> getChallenge(String url, [String challengeId = '']) async {
     Challenge challenge;
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    if (await hasInternet()) {
-      Response res = await _dio.get(url);
 
-      if (prefs.getString(url) == null) {
-        if (res.statusCode == 200) {
-          challenge = Challenge.fromJson(res.data);
-
-          prefs.setString(url, jsonEncode(res.data));
-
-          return challenge;
-        }
-      }
-
-      challenge = Challenge.fromJson(
-        jsonDecode(prefs.getString(url) as String),
-      );
+    Response res = await _dio.get(url);
+    if (res.statusCode == 200) {
+      challenge = Challenge.fromJson(res.data);
+      return challenge;
     } else {
-      String? challengeStr = prefs.getString(challengeId);
-      if (challengeStr == null) {
-        throw Exception('No internet connection and no stored challenge');
-      } else {
-        challenge = Challenge.fromJson(jsonDecode(challengeStr));
-      }
+      throw Exception('Please check your internet connection.');
     }
-    return challenge;
+
+    // SharedPreferences prefs = await SharedPreferences.getInstance();
+    // if (await hasInternet()) {
+    //   Response res = await _dio.get(url);
+
+    //   if (prefs.getString(url) == null) {
+    //     if (res.statusCode == 200) {
+    //       challenge = Challenge.fromJson(res.data);
+
+    //       prefs.setString(url, jsonEncode(res.data));
+
+    //       return challenge;
+    //     }
+    //   }
+
+    //   challenge = Challenge.fromJson(
+    //     jsonDecode(prefs.getString(url) as String),
+    //   );
+    // } else {
+    //   String? challengeStr = prefs.getString(challengeId);
+    //   if (challengeStr == null) {
+    //     throw Exception('No internet connection and no stored challenge');
+    //   } else {
+    //     challenge = Challenge.fromJson(jsonDecode(challengeStr));
+    //   }
+    // }
+    // return challenge;
   }
 
   /*


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
I've commented out the code which was "caching" challenge data so that when we come back to offline service we can discuss more about it.
