### PR TITLE
fix: chai.js pointing to new major version

### DIFF
--- a/mobile-app/lib/ui/views/learn/test_runner.dart
+++ b/mobile-app/lib/ui/views/learn/test_runner.dart
@@ -33,7 +33,7 @@ class TestRunner extends BaseViewModel {
     document = parse('');
 
     List<String> imports = [
-      '<script src="https://unpkg.com/chai/chai.js"></script>',
+      '<script src="https://unpkg.com/chai@4.3.10/chai.js"></script>',
       '<script src="https://unpkg.com/mocha/mocha.js"></script>',
       '<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>',
       '<link rel="stylesheet" href="https://unpkg.com/mocha/mocha.css" />'


### PR DESCRIPTION
Seems like UNPKG started linking Chai.js to a new major version. https://www.npmjs.com/package/chai?activeTab=versions v5 seems to be pretty new and not compatible with our test runner. 

We should probably link to specific version for Mocha too.

closes #1165 