### PR TITLE
fix: podcast episode preview content

### DIFF
--- a/mobile-app/lib/ui/widgets/podcast_widgets/podcast_tilte_widget.dart
+++ b/mobile-app/lib/ui/widgets/podcast_widgets/podcast_tilte_widget.dart
@@ -15,6 +15,7 @@ import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/service/podcast/download_service.dart';
 import 'package:freecodecamp/service/podcast/podcasts_service.dart';
 import 'package:freecodecamp/ui/views/podcast/episode/episode_view.dart';
+import 'package:html/parser.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -268,8 +269,7 @@ class PodcastTileState extends State<PodcastTile> {
                       podcast: widget.podcast,
                     ),
                     settings: RouteSettings(
-                        name:
-                            '/podcasts-episode/${widget.episode.title}'),
+                        name: '/podcasts-episode/${widget.episode.title}'),
                   ),
                 );
               }
@@ -434,23 +434,36 @@ class PodcastTileState extends State<PodcastTile> {
   }
 
   Padding descriptionWidget() {
+    final textContent = parse(widget.episode.description!).body?.text ?? '';
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: Html(
-        data: widget.podcast.description!,
-        onLinkTap: (url, attributes, element) {
-          launchUrl(Uri.parse(url!));
-        },
-        style: {
-          '#': Style(
-            fontSize: FontSize(16),
-            color: Colors.white.withOpacity(0.87),
-            margin: Margins.zero,
-            maxLines: 3,
-            fontFamily: 'Lato',
-          )
-        },
+      child: Text(
+        textContent,
+        maxLines: 3,
+        overflow: TextOverflow.ellipsis,
+        style: TextStyle(
+          fontSize: 16,
+          color: Colors.white.withOpacity(0.87),
+          fontFamily: 'Lato',
+        ),
       ),
+      // child: Html(
+      //   data: widget.episode.description!,
+      //   onLinkTap: (url, attributes, element) {
+      //     launchUrl(Uri.parse(url!));
+      //   },
+      //   style: {
+      //     '#': Style(
+      //       fontSize: FontSize(16),
+      //       color: Colors.white.withOpacity(0.87),
+      //       margin: Margins.zero,
+
+      //       fontFamily: 'Lato',
+      //     ),
+
+      //   },
+      //   maxLines:3,
+      // ),
     );
   }
 }

--- a/mobile-app/lib/ui/widgets/podcast_widgets/podcast_tilte_widget.dart
+++ b/mobile-app/lib/ui/widgets/podcast_widgets/podcast_tilte_widget.dart
@@ -5,7 +5,6 @@ import 'package:dio/dio.dart';
 import 'package:fk_user_agent/fk_user_agent.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_html/flutter_html.dart';
 import 'package:freecodecamp/app/app.locator.dart';
 import 'package:freecodecamp/extensions/i18n_extension.dart';
 import 'package:freecodecamp/models/podcasts/episodes_model.dart';
@@ -19,7 +18,6 @@ import 'package:html/parser.dart';
 import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 // ignore: must_be_immutable
 class PodcastTile extends StatefulWidget {
@@ -447,23 +445,6 @@ class PodcastTileState extends State<PodcastTile> {
           fontFamily: 'Lato',
         ),
       ),
-      // child: Html(
-      //   data: widget.episode.description!,
-      //   onLinkTap: (url, attributes, element) {
-      //     launchUrl(Uri.parse(url!));
-      //   },
-      //   style: {
-      //     '#': Style(
-      //       fontSize: FontSize(16),
-      //       color: Colors.white.withOpacity(0.87),
-      //       margin: Margins.zero,
-
-      //       fontFamily: 'Lato',
-      //     ),
-
-      //   },
-      //   maxLines:3,
-      // ),
     );
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
Removed HTML widget because of maxLines property did not work as expected if the content contains elements like line breaks or other block-level elements that can break the line. That's why I added the text widget, by parsing the body of the description used as textcontent in the widget. By using the text widget we can see max lines 3

Closes #1175

<!-- Feel free to add any additional description of changes below this line -->
