### PR TITLE
fix: Title of podcast should be truncated with dots if the text doesn't fit in its container. #1180

### DIFF
--- a/mobile-app/lib/ui/views/podcast/podcast-list/podcast_list_view.dart
+++ b/mobile-app/lib/ui/views/podcast/podcast-list/podcast_list_view.dart
@@ -188,25 +188,27 @@ class PodcastTemplate extends StatelessWidget {
               child: Row(
                 children: [
                   Expanded(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.black.withOpacity(0.75),
-                            spreadRadius: 1.5,
-                            blurRadius: 0.1,
-                          )
-                        ],
-                      ),
-                      child: Text('${podcast.title!}\n',
-                          maxLines: 2,
-                          textAlign: TextAlign.center,
-                          style: const TextStyle(
-                            fontSize: 16,
-                            height: 1.2,
-                          )),
+                      child: Container(
+                    decoration: BoxDecoration(
+                      boxShadow: [
+                        BoxShadow(
+                          color: Colors.black.withOpacity(0.75),
+                          spreadRadius: 1.5,
+                          blurRadius: 0.1,
+                        )
+                      ],
                     ),
-                  ),
+                    child: Text(
+                      '${podcast.title!}\n',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(
+                        fontSize: 16,
+                        height: 1.2,
+                      ),
+                    ),
+                  )),
                 ],
               ),
             ),


### PR DESCRIPTION
added overflow ellipsis to podcast title as requested.