### PR TITLE
fix: ci grant permission

### DIFF
--- a/mobile-app/pubspec.lock
+++ b/mobile-app/pubspec.lock
@@ -487,7 +487,7 @@ packages:
     source: hosted
     version: "5.1.0"
   flutter_driver:
-    dependency: transitive
+    dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -59,6 +59,8 @@ dependencies:
     sdk: flutter
 dev_dependencies:
   build_runner: ^2.1.2
+  flutter_driver:
+    sdk: flutter
   integration_test:
     sdk: flutter
   flutter_test:

--- a/mobile-app/test_driver/integration_test.dart
+++ b/mobile-app/test_driver/integration_test.dart
@@ -1,7 +1,26 @@
 import 'dart:io';
+
+import 'package:flutter_driver/flutter_driver.dart';
 import 'package:integration_test/integration_test_driver_extended.dart';
 
 Future<void> main() async {
+  FlutterDriver driver = await FlutterDriver.connect();
+  final vm = await driver.serviceClient.getVM();
+  final platform = vm.operatingSystem;
+
+  if (platform!.toLowerCase().contains('android')) {
+    Process.runSync(
+      'adb',
+      [
+        'shell',
+        'pm',
+        'grant',
+        'org.freecodecamp',
+        'android.permission.POST_NOTIFICATIONS'
+      ],
+    );
+  }
+
   try {
     await integrationDriver(
       onScreenshot: (String screenshotName, List<int> screenshotBytes,


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->
The CI test was failing for android devices because in PR #1225 I had bumped the android version to API 33(Android 13) to be in line with the target version present in the android config files. In Android 13, the notification permission dialog was introduced and since the tests were not updated to handle it, they were all waiting for a response thereby leading to the action to never end & overtime at 6 hrs.

Thanks to the folks who solved this bounty(https://github.com/FilledStacks/acceptpermission_bounty/pull/1) I could get this to work locally. Now to test it in the CI 🤞
