### PR TITLE
fix: return type of parseExt from api data

### DIFF
--- a/mobile-app/lib/enums/ext_type.dart
+++ b/mobile-app/lib/enums/ext_type.dart
@@ -1,6 +1,6 @@
 enum Ext { js, html, css, jsx }
 
-parseExt(String ext) {
+Ext parseExt(String ext) {
   switch (ext) {
     case 'js':
       return Ext.js;
@@ -11,6 +11,6 @@ parseExt(String ext) {
     case 'jsx':
       return Ext.jsx;
     default:
-      return 'html';
+      return Ext.html;
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I believe this is the cause of the below Crashlytics report.

<!-- Feel free to add any additional description of changes below this line -->
Crashlytics reports
- https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/ios:org.freecodecamp.ios/issues/83caeef22555e1af692689e727621047
- https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/android:org.freecodecamp/issues/34fde8f1fe309bbdbf007344afa9a696
