### PR TITLE
fix: add back button to news tutorial image viewer

### DIFF
--- a/mobile-app/lib/ui/views/news/news-image-viewer/news_image_view.dart
+++ b/mobile-app/lib/ui/views/news/news-image-viewer/news_image_view.dart
@@ -20,6 +20,19 @@ class NewsImageView extends StatelessWidget {
     return ViewModelBuilder.nonReactive(
       viewModelBuilder: () => NewsImageModel(),
       builder: (context, model, child) => Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          shadowColor: Colors.transparent,
+          leading: Tooltip(
+                message: 'Back',
+                child: InkWell(
+                  onTap: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Icon(Icons.arrow_back),
+                ),
+              ),
+        ),
         body: PhotoView(
           backgroundDecoration: const BoxDecoration(
             color: Color.fromRGBO(0x2A, 0x2A, 0x40, 1),


### PR DESCRIPTION
Checklist:

-  [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
-  [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) 

Closes #1315

<img width="250" alt="news image viewer" src="https://github.com/user-attachments/assets/34b17b51-c2e2-43c1-9800-e6d7250473ab">

- The PR is created to improve to the functioinality of the news image viewer button on iOS
- I added a back button to the page to navigate back to the tutorial page