### PR TITLE
fix: full screen issue for youtube videos played in tutorials

### DIFF
--- a/mobile-app/.gitignore
+++ b/mobile-app/.gitignore
@@ -1,0 +1,4 @@
+
+# FVM Version Cache
+.fvm/
+.fvmrc

--- a/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
@@ -43,6 +43,23 @@ class MultipleChoiceView extends StatelessWidget {
           ),
         );
 
+        controller.setFullScreenListener(
+          (_) async {
+            final videoData = await controller.videoData;
+            final startSeconds = await controller.currentTime;
+
+            final currentTime = await FullscreenYoutubePlayer.launch(
+              context,
+              videoId: videoData.videoId,
+              startSeconds: startSeconds,
+            );
+
+            if (currentTime != null) {
+              controller.seekTo(seconds: currentTime);
+            }
+          },
+        );
+
         int numberOfDialogueHeaders = block.challenges
             .where((challenge) => challenge.title.contains('Dialogue'))
             .length;

--- a/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
@@ -40,6 +40,23 @@ class PythonView extends StatelessWidget {
           ),
         );
 
+        controller.setFullScreenListener(
+          (_) async {
+            final videoData = await controller.videoData;
+            final startSeconds = await controller.currentTime;
+
+            final currentTime = await FullscreenYoutubePlayer.launch(
+              context,
+              videoId: videoData.videoId,
+              startSeconds: startSeconds,
+            );
+
+            if (currentTime != null) {
+              controller.seekTo(seconds: currentTime);
+            }
+          },
+        );
+
         return PopScope(
           canPop: true,
           onPopInvokedWithResult: (bool didPop, dynamic result) {


### PR DESCRIPTION
1. Fixed full screen issue for youtube videos played in tutorials - this is done by adding a callback for fullscreen listener as specified in the library documentation ([example app](https://github.com/sarbagyastha/youtube_player_flutter/blob/aecc29691cfa6828e48547515f80737df7cd82aa/packages/youtube_player_iframe/example/lib/pages/video_list_page.dart#L42))
3. Added gitignore file inside the `mobile-app` directory and added fvm related files for developers who use fvm

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1306

<!-- Feel free to add any additional description of changes below this line -->

**Additional comments:**

When trying to run the app on android emulator, the **TUTORIALS** page does not load (from the side-drawer menu). I got the following error:
` [ERROR:flutter/runtime/dart_vm_initializer.cc(40)] Unhandled Exception: Exception: OperationException(linkException: null, graphqlErrors: [GraphQLError(message: Variable "$publicationId" got invalid value ""; Expected type "ObjectId". Value is not a valid mongodb object id of form: , locations: [ErrorLocation(line: 1, column: 19)], path: null, extensions: {code: BAD_USER_INPUT})])
E/flutter (16507): #0      NewsApiServive.getAllPosts (package:freecodecamp/service/news/api_service.dart:170:7)
E/flutter (16507): <asynchronous suspension>
E/flutter (16507): #1      NewsFeedViewModel.fetchTutorials (package:freecodecamp/ui/views/news/news-feed/news_feed_viewmodel.dart:83:14)
E/flutter (16507): <asynchronous suspension>`

I was able not able to locate the exact file that renders the youtube video for tutorials as the data was not loading due to the above issue. To address the issue, I selected a regular course from the home page that contains an embedded YouTube video rendered using the YouTube player library. Kindly let me know if this change needs to be applied to all other pages/files where YouTube videos are rendered.
