### PR TITLE
fix: title of mario block in help categories

### DIFF
--- a/mobile-app/assets/learn/help-category.json
+++ b/mobile-app/assets/learn/help-category.json
@@ -64,7 +64,7 @@
   "intermediate-javascript-calorie-counter": "JavaScript",
   "d3-dashboard": "JavaScript",
   "learn-bash-by-building-a-boilerplate": "Backend Development",
-  "learn-relational-databases-by-building-a-mario-database": "Backend Development",
+  "learn-relational-databases-by-building-a-database-of-video-game-characters": "Backend Development",
   "celestial-bodies-database": "Backend Development",
   "learn-bash-scripting-by-building-five-programs": "Backend Development",
   "learn-bash-and-sql-by-building-a-bike-rental-shop": "Backend Development",


### PR DESCRIPTION
Hey @Sembauke @Nirajn2311 - I am renaming this block and title on the main repo - will link the PR for that when it's ready. Found this in the mobile codebase. Would it be better to just include both titles for now?

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
