### PR TITLE
fix: dont ask permissions before notification initialization

### DIFF
--- a/mobile-app/ios/Podfile.lock
+++ b/mobile-app/ios/Podfile.lock
@@ -200,7 +200,7 @@ PODS:
   - sqflite (0.0.3):
     - Flutter
     - FlutterMacOS
-  - ua_client_hints (1.2.2):
+  - ua_client_hints (1.4.1):
     - Flutter
   - url_launcher_ios (0.0.1):
     - Flutter
@@ -358,7 +358,7 @@ SPEC CHECKSUMS:
   shared_preferences_foundation: b4c3b4cddf1c21f02770737f147a3f5da9d39695
   SimpleKeychain: 130211269f88f038d7dc5254cf0b1b9ce978c398
   sqflite: 673a0e54cc04b7d6dba8d24fb8095b31c3a99eec
-  ua_client_hints: 7f4e0f5d390685e8f7efd6eb363594f760108926
+  ua_client_hints: aeabd123262c087f0ce151ef96fa3ab77bfc8b38
   url_launcher_ios: 5334b05cef931de560670eeae103fd3e431ac3fe
   webview_flutter_wkwebview: be0f0d33777f1bfd0c9fdcb594786704dbf65f36
 

--- a/mobile-app/lib/service/podcast/notification_service.dart
+++ b/mobile-app/lib/service/podcast/notification_service.dart
@@ -34,12 +34,12 @@ class NotificationService {
       iOS: iosInitializationSettings,
     );
 
+    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+
     await _flutterLocalNotificationsPlugin
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>()
         ?.requestNotificationsPermission();
-
-    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
   }
 
   Future<void> showNotification(String title, String body) async {

--- a/mobile-app/lib/service/podcast/notification_service.dart
+++ b/mobile-app/lib/service/podcast/notification_service.dart
@@ -1,4 +1,5 @@
 import 'dart:developer' as dev;
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -36,10 +37,12 @@ class NotificationService {
 
     await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
 
-    await _flutterLocalNotificationsPlugin
-        .resolvePlatformSpecificImplementation<
-            AndroidFlutterLocalNotificationsPlugin>()
-        ?.requestNotificationsPermission();
+    if (Platform.isAndroid) {
+      await _flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>()
+          ?.requestNotificationsPermission();
+    }
   }
 
   Future<void> showNotification(String title, String body) async {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

Should hopefully fix this issue: https://console.firebase.google.com/u/1/project/mobile-4ee8a/crashlytics/app/android:org.freecodecamp/issues/c58e4e6ccdc6385ec7464bf3086b9cec?time=last-seven-days&types=crash&sessionEventKey=67B8339000F400012B7FB8141713DCCA_2052225893469884727

<!-- Feel free to add any additional description of changes below this line -->
