### PR TITLE
fix(a11y): improve contrast ratio of complete button

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -403,7 +403,7 @@ class ChallengeView extends StatelessWidget {
                       color: !model.hasTypedInEditor
                           ? const Color.fromARGB(255, 9, 79, 125)
                           : model.completedChallenge
-                              ? const Color.fromRGBO(0x20, 0xD0, 0x32, 1)
+                              ? const Color.fromRGBO(60, 118, 61, 1)
                               : const Color.fromRGBO(0x1D, 0x9B, 0xF0, 1),
                       child: IconButton(
                         icon: model.runningTests

--- a/mobile-app/lib/ui/views/learn/widgets/dynamic_panel/panels/pass/pass_widget_view.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/dynamic_panel/panels/pass/pass_widget_view.dart
@@ -211,7 +211,7 @@ class PassButton extends StatelessWidget {
           );
         },
         style: TextButton.styleFrom(
-          backgroundColor: const Color.fromRGBO(0x20, 0xD0, 0x32, 1),
+          backgroundColor: const Color.fromRGBO(60, 118, 61, 1),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(0),
           ),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I'm setting the background color of the complete challenge button to `green40` to improve the contrast ratio between the text and the background.

Here is the value of `green40`: (https://github.com/freeCodeCamp/ui/blob/e541d9e25d604e93ca3e6ff6399d30645d7bc3a1/src/colors.css#L39).

<details>
  <summary>Screenshots</summary>

| Before | After |
| --- | --- |
| ![Simulator Screenshot - iPhone Xʀ - 2025-03-26 at 15 19 15](https://github.com/user-attachments/assets/496c0fd2-5291-4d37-9b0e-87633a5a5c0c) | ![Simulator Screenshot - iPhone Xʀ - 2025-03-26 at 14 58 28](https://github.com/user-attachments/assets/63e6c87c-1ac9-4615-97b1-4640b86c099d) |

</details>

<!-- Feel free to add any additional description of changes below this line -->
