### PR TITLE
refactor: move repos in CI so it's easier to test locally

### DIFF
--- a/.github/workflows/mobile-curriculum-e2e.yml
+++ b/.github/workflows/mobile-curriculum-e2e.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           repository: freeCodeCamp/freeCodeCamp
+          path: freeCodeCamp
 
       - name: Checkout mobile repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -53,30 +54,34 @@ jobs:
           cache-path: ${{ runner.tool_cache }}/flutter
 
       - name: Set freeCodeCamp Environment Variables
+        working-directory: freeCodeCamp
         run: cp sample.env .env
 
-      - name: Install and Build
+      - name: Install and Build Curriculum
+        working-directory: freeCodeCamp
         run: |
           pnpm install
           pnpm run create:shared
           pnpm run build:curriculum
 
       - name: Generate mobile test files
+        working-directory: mobile/mobile-app
         run: |
-          cd mobile/mobile-app
           echo "DEVELOPMENTMODE=true" > .env
           echo "HASHNODE_PUBLICATION_ID=$HASHNODE_PUBLICATION_ID" > .env
           flutter pub get
           flutter test test/widget_test.dart
 
       - name: Install playwright dependencies
+        working-directory: mobile
         run: npx playwright install --with-deps
 
       - name: Install serve
         run: npm install -g serve
 
       - name: Run playwright tests
-        run: npx playwright test --config=mobile/e2e/playwright.config.js
+        working-directory: mobile
+        run: npx playwright test --config=e2e/playwright.config.js
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: ${{ !cancelled() }}

--- a/e2e/learn.spec.js
+++ b/e2e/learn.spec.js
@@ -1,10 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-// These are all in the freeCodeCamp repo. That repo is installed at the root
-// in CI.
-import currData from "../../shared/config/curriculum.json";
-import { orderedSuperBlockInfo } from "../../tools/scripts/build/build-external-curricula-data";
-import { SuperBlocks } from "../../shared/config/curriculum";
+// These are all in the freeCodeCamp repo. That repo is installed alongside this
+// repo in CI. i.e. the structure is:
+//
+// workspace-root/freeCodeCamp
+// workspace-root/mobile
+
+import currData from "../../freeCodeCamp/shared/config/curriculum.json";
+import { orderedSuperBlockInfo } from "../../freeCodeCamp/tools/scripts/build/build-external-curricula-data";
+import { SuperBlocks } from "../../freeCodeCamp/shared/config/curriculum";
 
 // non editor superblocks should be skipped because they are not
 // checked if they are compatible with the mobile app.
@@ -16,7 +20,7 @@ const nonEditorSB = [
   SuperBlocks.CollegeAlgebraPy,
   SuperBlocks.A2English,
   SuperBlocks.B1English,
-  SuperBlocks.TheOdinProject
+  SuperBlocks.TheOdinProject,
 ];
 
 const publicSB = orderedSuperBlockInfo


### PR DESCRIPTION
Rather than installing the freeCodeCamp repo at root and then putting mobile in a sub-dir, the workflow puts them in sibling folders. That makes it easier to work with locally, since you can work on the repos independently.

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
