### PR TITLE
Revert "fix: bookmark test"

### DIFF
--- a/mobile-app/integration_test/news/bookmark_test.dart
+++ b/mobile-app/integration_test/news/bookmark_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:freecodecamp/main.dart' as app;
 import 'package:freecodecamp/ui/views/news/news-tutorial/news_tutorial_view.dart';
@@ -7,10 +6,10 @@ import 'package:integration_test/integration_test.dart';
 import 'package:path/path.dart' as path;
 import 'package:sqflite/sqflite.dart';
 
-Future main() async {
+void main() {
   final binding = IntegrationTestWidgetsFlutterBinding();
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
-  await dotenv.load();
+
   testWidgets('NEWS - should bookmark tutorial', (WidgetTester tester) async {
     // Start app and navigate to news view
     tester.printToConsole('Test starting');


### PR DESCRIPTION
Reverts freeCodeCamp/mobile#1377

The PR doesn't fix the test as PRs from forked repos won't get access to secrets in the actions for security reasons and so the CI actions will fail. Yes, this is a known problem and should be fixed with mocking of api responses