### PR TITLE
fix: link text color

### DIFF
--- a/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
+++ b/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
@@ -114,7 +114,7 @@ class HTMLParser {
         'a': Style(
           color: Colors.white,
           textDecoration: TextDecoration.underline,
-          textDecorationColor: Colors.blue,
+          textDecorationColor: Colors.white,
         ),
         'li': Style(
           margin: Margins.only(top: 8),

--- a/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
+++ b/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
@@ -112,7 +112,7 @@ class HTMLParser {
           lineHeight: const LineHeight(1.5),
         ),
         'a': Style(
-          color: Colors.blue,
+          color: Colors.white,
           textDecoration: TextDecoration.underline,
         ),
         'li': Style(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Changes link text color from blue to white, to improve readability and a11y. We also use white for link text in the web version, so this change is also to align with that.

<details>
  <summary>Screenshots</summary>
  
  | Before | After |
  | --- | --- |
  | ![Simulator Screenshot - iPhone Xʀ - 2025-04-16 at 16 11 28](https://github.com/user-attachments/assets/13725ccc-128e-4ec7-a8cd-694490e99c53) | ![Simulator Screenshot - iPhone Xʀ - 2025-04-16 at 16 10 51](https://github.com/user-attachments/assets/bcc4ecfc-2c69-4a8b-882a-72a22abb4fb3) |
</details>

<!-- Feel free to add any additional description of changes below this line -->
