### PR TITLE
fix: upgrade dialog

### DIFF
--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -92,7 +92,6 @@ class FreeCodeCampMobileApp extends StatelessWidget {
                   ? UpgradeDialogStyle.cupertino
                   : UpgradeDialogStyle.material,
               showIgnore: false,
-              showLater: false,
               upgrader: upgraderController,
               child: child,
             );


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->


<!-- Feel free to add any additional description of changes below this line -->
Show the later button in the upgrade dialog when the current app version is not lesser than the minimum app version. Currently because the later option is disabled, the users are always forced to update app even if their app version is not less than the minimum app version.