### PR TITLE
chore(service): use v2 submit-types.json

### DIFF
--- a/mobile-app/lib/service/learn/learn_service.dart
+++ b/mobile-app/lib/service/learn/learn_service.dart
@@ -21,7 +21,10 @@ class LearnService {
 
   final Dio _dio = DioService.dio;
 
+  // TODO: change this to v2 and remove baseUrlV2 once the migration is complete
   static final baseUrl = '${AuthenticationService.baseURL}/curriculum-data/v1';
+  static final baseUrlV2 =
+      '${AuthenticationService.baseURL}/curriculum-data/v2';
 
   final LearnOfflineService learnOfflineService =
       locator<LearnOfflineService>();
@@ -50,8 +53,7 @@ class LearnService {
     String challengeId = challenge.id;
     int challengeType = challenge.challengeType;
 
-    Response submitTypesRes = await _dio.get(
-        '${AuthenticationService.baseURL}/curriculum-data/submit-types.json');
+    Response submitTypesRes = await _dio.get('$baseUrlV2/submit-types.json');
     Map<String, dynamic> submitTypes = submitTypesRes.data;
 
     switch (submitTypes[challengeType.toString()]) {


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

v2 is now live so I'm just creating PRs targeting `main` instead of a feature branch.

This PR:
- Uses curriculum data v2 for `submit-types.json`
  - There is no differences in the file content, we just moved the file under `/curriculum-data/v2` now, rather than leaving it in the `/curriculum-data` root. This apparently is a bug in v1, we expect the file to be under `/curriculum-data/v1`, but this isn't flagged by the test because the test case is missing an assertion (`expect()`): https://github.com/freeCodeCamp/freeCodeCamp/blob/181321d90dffd8ed2e27fd76eebd5dbc013b9730/tools/scripts/build/build-external-curricula-data-v1.test.ts#L41-L45
- Is related to #1426

<!-- Feel free to add any additional description of changes below this line -->
