### PR TITLE
chore(viewmodel): use challenges data v2

### DIFF
--- a/mobile-app/lib/ui/views/learn/block/block_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/block/block_viewmodel.dart
@@ -188,7 +188,7 @@ class BlockViewModel extends BaseViewModel {
   }
 
   Future<void> startDownload(Block block) async {
-    String url = LearnService.baseUrl;
+    String url = LearnService.baseUrlV2;
     learnOfflineService
         .getChallengeBatch(
       block,

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -450,7 +450,7 @@ class ChallengeViewModel extends BaseViewModel {
       );
 
       String slug = block!.challengeTiles[challengeIndex].id;
-      String url = LearnService.baseUrl;
+      String url = LearnService.baseUrlV2;
       String challengeUrl =
           '$url/challenges/${block!.superBlock.dashedName}/${block!.dashedName}/$slug.json';
 

--- a/mobile-app/lib/ui/views/learn/challenge/templates/template_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/template_viewmodel.dart
@@ -18,7 +18,7 @@ class ChallengeTemplateViewModel extends BaseViewModel {
   }
 
   void initiate(Block block, String challengeId) {
-    final String base = LearnService.baseUrl;
+    final String base = LearnService.baseUrlV2;
 
     String url =
         '$base/challenges/${block.superBlock.dashedName}/${block.dashedName}/$challengeId.json';

--- a/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
@@ -93,7 +93,7 @@ class LearnLandingViewModel extends BaseViewModel {
         lastVisitedChallenge[0],
       );
 
-      String baseUrl = LearnService.baseUrl;
+      String baseUrl = LearnService.baseUrlV2;
 
       final Response res =
           await _dio.get('$baseUrl/${lastVisitedChallenge[1]}.json');


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the app to use v2 of `/challenges` data
  - This is just a simple version switch, there were no changes in the schema of the challenge JSON files
- Is related to #1426

<!-- Feel free to add any additional description of changes below this line -->
