### PR TITLE
feat(view): add explanation to fill in the blanks challenge

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
@@ -5,7 +5,9 @@ import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/templates/english/english_viewmodel.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/audio/audio_player_view.dart';
+import 'package:freecodecamp/ui/views/learn/widgets/explanation_widget.dart';
 import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
+import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_view.dart';
 import 'package:stacked/stacked.dart';
 
 class EnglishView extends StatelessWidget {
@@ -159,6 +161,10 @@ class EnglishView extends StatelessWidget {
                             ],
                           ),
                         ),
+                      ],
+                      if (challenge.explanation != null &&
+                          challenge.explanation!.isNotEmpty) ...[
+                        Explanation(challenge: challenge),
                       ],
                       Row(
                         children: [

--- a/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
@@ -5,6 +5,7 @@ import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_viewmodel.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/audio/audio_player_view.dart';
+import 'package:freecodecamp/ui/views/learn/widgets/explanation_widget.dart';
 import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_view.dart';
 import 'package:stacked/stacked.dart';
@@ -27,6 +28,9 @@ class MultipleChoiceView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     HTMLParser parser = HTMLParser(context: context);
+
+    bool shouldShowExplanation =
+        challenge.explanation != null && challenge.explanation!.isNotEmpty;
 
     return ViewModelBuilder<MultipleChoiceViewmodel>.reactive(
       viewModelBuilder: () => MultipleChoiceViewmodel(),
@@ -162,30 +166,8 @@ class MultipleChoiceView extends StatelessWidget {
                   const SizedBox(height: 8),
                   if (challenge.explanation != null &&
                       challenge.explanation!.isNotEmpty) ...[
-                    ExpansionTile(
-                      title: Text(
-                        'Explanation',
-                        style: TextStyle(
-                          fontSize: FontSize.large.value,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      shape: RoundedRectangleBorder(
-                        side: BorderSide.none,
-                        borderRadius: BorderRadius.zero,
-                      ),
-                      collapsedShape: RoundedRectangleBorder(
-                        side: BorderSide.none,
-                        borderRadius: BorderRadius.zero,
-                      ),
-                      children: [
-                        const SizedBox(height: 8),
-                        ...parser.parse(challenge.explanation!),
-                        const SizedBox(height: 8),
-                      ],
-                    ),
+                    Explanation(challenge: challenge),
                   ],
-                  buildDivider(),
                   const SizedBox(height: 16),
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(

--- a/mobile-app/lib/ui/views/learn/widgets/explanation_widget.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/explanation_widget.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_html/flutter_html.dart';
+import 'package:freecodecamp/models/learn/challenge_model.dart';
+import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
+import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_view.dart';
+
+class Explanation extends StatelessWidget {
+  const Explanation({
+    super.key,
+    required this.challenge,
+  });
+
+  final Challenge challenge;
+
+  @override
+  Widget build(BuildContext context) {
+    HTMLParser parser = HTMLParser(context: context);
+
+    return Column(
+      children: [
+        ExpansionTile(
+          title: Text(
+            'Explanation',
+            style: TextStyle(
+              fontSize: FontSize.large.value,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          shape: RoundedRectangleBorder(
+            side: BorderSide.none,
+            borderRadius: BorderRadius.zero,
+          ),
+          collapsedShape: RoundedRectangleBorder(
+            side: BorderSide.none,
+            borderRadius: BorderRadius.zero,
+          ),
+          children: [
+            const SizedBox(height: 8),
+            ...parser.parse(challenge.explanation!),
+            const SizedBox(height: 8),
+          ],
+        ),
+        buildDivider(),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

This PR:
- Moves the explanation implementation to a shared widget.
- Displays the explanation widget on fill in the blanks challenges. (This is a follow-up to #1462. We only added explanation to multiple-choice question challenges in that PR because I forgot that `explanation` is also available in fill in the blanks challenges.)

<details>
  <summary>Screenshots</summary>

  | Multiple-choice question | Fill in the blanks |
  | --- | --- |
  | <img width="409" alt="Screenshot 2025-05-08 at 18 13 24" src="https://github.com/user-attachments/assets/3dcc9bc5-410d-45fc-9c54-ebc7cded4417" /> | <img width="413" alt="Screenshot 2025-05-08 at 18 13 39" src="https://github.com/user-attachments/assets/deea05bd-924a-4244-ae15-392484c4db04" /> |
</details>
