### PR TITLE
fix(multiple-choice): align question text to the start in MultipleChoiceView

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
@@ -136,6 +136,7 @@ class MultipleChoiceView extends StatelessWidget {
                   ChallengeCard(
                     title: 'Question',
                     child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
                         ...parser.parse(
                           challenge.question!.text,


### PR DESCRIPTION
The question text was centered:

<details><summary>Before</summary>
<p>
<img width="384" alt="image" src="https://github.com/user-attachments/assets/397909e4-98a9-4761-bc86-485845b4426f" />



</p>
</details> 

<details><summary>After</summary>
<p>
<img width="384" alt="image" src="https://github.com/user-attachments/assets/7fe1f6c6-d9d0-4a4d-bae6-c57c0c80fb6b" />

</p>
</details> 