### PR TITLE
fix(view): minor improvements to login view

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -64,10 +64,6 @@
     "@email": {
         "description": "login view"
     },
-    "email_sign_in_code": "Email a sign in code",
-    "@email_sign_in_code": {
-        "description": "login view"
-    },
     "email_enter_sign_in_code": "Enter sign in code",
     "@email_enter_sign_in_code": {
         "description": "login view"

--- a/mobile-app/lib/l10n/app_es.arb
+++ b/mobile-app/lib/l10n/app_es.arb
@@ -64,10 +64,6 @@
   "@email": {
       "description": "login view"
   },
-  "email_sign_in_code": "Email a sign in code",
-  "@email_sign_in_code": {
-      "description": "login view"
-  },
   "email_enter_sign_in_code": "Enter sign in code",
   "@email_enter_sign_in_code": {
       "description": "login view"

--- a/mobile-app/lib/l10n/app_pt.arb
+++ b/mobile-app/lib/l10n/app_pt.arb
@@ -64,10 +64,6 @@
   "@email": {
       "description": "login view"
   },
-  "email_sign_in_code": "Email a sign in code",
-  "@email_sign_in_code": {
-      "description": "login view"
-  },
   "email_enter_sign_in_code": "Enter sign in code",
   "@email_enter_sign_in_code": {
       "description": "login view"

--- a/mobile-app/lib/ui/theme/fcc_theme.dart
+++ b/mobile-app/lib/ui/theme/fcc_theme.dart
@@ -58,6 +58,7 @@ class FccSemanticColors {
   static const foregroundSuccess = FccColors.green90;
   static const foregroundInfo = FccColors.blue90;
   static const foregroundWarning = FccColors.yellow40;
+  static const foregroundCta = FccColors.gray90;
 
   static const backgroundPrimary = FccColors.gray90;
   static const backgroundSecondary = FccColors.gray85;
@@ -67,6 +68,7 @@ class FccSemanticColors {
   static const backgroundSuccess = FccColors.green40;
   static const backgroundInfo = FccColors.blue30;
   static const backgroundSelection = FccColors.blue30Translucent;
+  static const backgroundCta = FccColors.yellow40;
 }
 
 class FccTheme {

--- a/mobile-app/lib/ui/views/login/native_login_view.dart
+++ b/mobile-app/lib/ui/views/login/native_login_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:freecodecamp/extensions/i18n_extension.dart';
+import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:freecodecamp/ui/views/login/native_login_viewmodel.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_view.dart';
 import 'package:stacked/stacked.dart';
@@ -26,6 +27,17 @@ class NativeLoginView extends StatelessWidget {
     TextStyle textStyle = const TextStyle(
       fontSize: 20,
       color: Colors.black,
+    );
+
+    ButtonStyle ctaButtonStyle = ElevatedButton.styleFrom(
+      backgroundColor: FccSemanticColors.backgroundCta,
+      foregroundColor: FccSemanticColors.foregroundCta,
+      disabledBackgroundColor:
+          Color(0xCCFFC300), // backgroundCta with 80% opacity
+      disabledForegroundColor: FccSemanticColors.foregroundCta,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(0),
+      ),
     );
 
     return ViewModelBuilder<NativeLoginViewModel>.reactive(
@@ -170,7 +182,7 @@ class NativeLoginView extends StatelessWidget {
                           controller: model.otpController,
                           keyboardType: TextInputType.number,
                           decoration: InputDecoration(
-                            hintText: context.t.email_sign_in_code,
+                            hintText: context.t.email_enter_sign_in_code,
                             errorText: model.incorrectOTP
                                 ? context.t.email_invalid_code
                                 : null,
@@ -190,7 +202,7 @@ class NativeLoginView extends StatelessWidget {
                         child: Container(
                           margin: const EdgeInsets.all(16),
                           child: ElevatedButton(
-                            style: buttonStyle.copyWith(
+                            style: ctaButtonStyle.copyWith(
                               padding: const WidgetStatePropertyAll(
                                 EdgeInsets.symmetric(vertical: 8),
                               ),
@@ -202,7 +214,9 @@ class NativeLoginView extends StatelessWidget {
                                 : null,
                             child: Text(
                               'Submit and sign in to freeCodeCamp',
-                              style: textStyle,
+                              style: TextStyle(
+                                fontSize: 20,
+                              ),
                               textAlign: TextAlign.center,
                             ),
                           ),
@@ -214,7 +228,7 @@ class NativeLoginView extends StatelessWidget {
                           margin: const EdgeInsets.all(16),
                           constraints: const BoxConstraints(minHeight: 50),
                           child: ElevatedButton(
-                            style: buttonStyle,
+                            style: ctaButtonStyle,
                             onPressed: model.emailFieldIsValid
                                 ? () {
                                     model.sendOTPtoEmail();
@@ -225,7 +239,9 @@ class NativeLoginView extends StatelessWidget {
                               child: Align(
                                 child: Text(
                                   context.t.email_submit_code,
-                                  style: textStyle,
+                                  style: TextStyle(
+                                    fontSize: 20,
+                                  ),
                                   textAlign: TextAlign.center,
                                 ),
                               ),


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Changes the submit button on login view to use gold + dark blue color combination
- Uses the correct placeholder text for the OTP input field

<details>
  <summary>Screenshots</summary>

  |  | Before | After |
  | --- | --- | --- |
  | Disabled | <img width="412" alt="Screenshot 2025-05-16 at 00 44 05" src="https://github.com/user-attachments/assets/d073e67a-6df6-43d5-b591-a2e0eba30717" /> | <img width="410" alt="Screenshot 2025-05-16 at 01 08 06" src="https://github.com/user-attachments/assets/8cb9ee8b-0e6c-4f63-bba8-9831728f3052" /> |
  | Enabled | <img width="410" alt="Screenshot 2025-05-16 at 01 20 00" src="https://github.com/user-attachments/assets/c410561b-be50-4632-b3aa-8b5a0b85bbd5" /> | <img width="410" alt="Screenshot 2025-05-16 at 01 19 23" src="https://github.com/user-attachments/assets/771013d6-1e0f-4509-b55e-4e453736183c" /> | 

</details>

<!-- Feel free to add any additional description of changes below this line -->
