### PR TITLE
fix(view): move feedback below fill in the blank section

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
@@ -61,13 +61,6 @@ class EnglishView extends StatelessWidget {
                       ),
                     ),
                   ],
-                  if (model.feedback.isNotEmpty)
-                    ChallengeCard(
-                      title: 'Feedback',
-                      child: Column(
-                        children: parser.parse(model.feedback),
-                      ),
-                    ),
                   if (challenge.fillInTheBlank != null)
                     ChallengeCard(
                       title: 'Fill in the Blank',
@@ -79,6 +72,13 @@ class EnglishView extends StatelessWidget {
                             context,
                           ),
                         ),
+                      ),
+                    ),
+                  if (model.feedback.isNotEmpty)
+                    ChallengeCard(
+                      title: 'Feedback',
+                      child: Column(
+                        children: parser.parse(model.feedback),
                       ),
                     ),
                   if (challenge.explanation != null &&


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

When the fill in the blank challenge is in the initial state, feedback doesn't show up. When the user tap the check button, the feedback section appears in the "Fill in the blank" section and pushes that section down. This might be disorienting as the user needs to re-adjust in order to continue to interact with the blanks / text fields. 

This PR swaps the placement of the "Feedback"  and "Fill in the blank" sections.

<details>
<summary>Screenshot</summary>

| Before | After |
| --- | --- |
| <img width="410" alt="Screenshot 2025-05-16 at 01 31 09" src="https://github.com/user-attachments/assets/8626e698-4679-4280-903d-8bec89b93d7e" /> | <img width="410" alt="Screenshot 2025-05-16 at 01 29 51" src="https://github.com/user-attachments/assets/f24560e0-27c7-43d5-9c15-cf1ff6c82426" /> |

</details>

<!-- Feel free to add any additional description of changes below this line -->
