### PR TITLE
feat(view): move submit button to bottom bar on quiz view

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_view.dart
@@ -161,6 +161,9 @@ class QuizView extends StatelessWidget {
                               challenge,
                               block,
                             );
+                          } else if (model.isValidated &&
+                              !model.hasPassedAllQuestions) {
+                            model.resetQuiz();
                           } else {
                             model.validateChallenge();
                           }

--- a/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_viewmodel.dart
@@ -107,4 +107,17 @@ class QuizViewModel extends BaseViewModel {
         ? '✅ You have $correctQuestionsCount out of $totalQuestions questions correct. You have passed.'
         : "❌ You have $correctQuestionsCount out of $totalQuestions questions correct. You didn't pass.";
   }
+
+  void resetQuiz() {
+    setQuizQuestions = quizQuestions
+        .map((q) => QuizWidgetQuestion(
+              text: q.text,
+              answers: q.answers,
+              solution: q.solution,
+            ))
+        .toList();
+
+    setIsValidated = false;
+    setErrMessage = '';
+  }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates the Quiz view to display the submit button and the error message in a bottom bar
  - This is because on validation the feedback appears and causes the view height to expand, which pushes the submit button and the error message further down and out of view. I don't think we can address the jumpiness completely because we can't predict / assume the length of the feedback text. So pinning the message and the action button is my only option
- Updates the "Try Again" button logic to reset the quiz 
  - I missed this in the Quiz view implementation, and currently the Try Again button would try to validate the selected answers rather than resetting the quiz

<details>
<summary>Screen recording</summary>

https://github.com/user-attachments/assets/48b80015-1bee-491d-9f8c-b5aefae9cd9c

</details>

<!-- Feel free to add any additional description of changes below this line -->
