### PR TITLE
fix(view, viewmodel): cache parsed html for review page

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
@@ -8,7 +8,6 @@ import 'package:freecodecamp/ui/views/learn/utils/challenge_utils.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/assignment_widget.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_card.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/youtube_player_widget.dart';
-import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
 import 'package:stacked/stacked.dart';
 
 class ReviewView extends StatelessWidget {
@@ -25,11 +24,9 @@ class ReviewView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    HTMLParser parser = HTMLParser(context: context);
-
     return ViewModelBuilder<ReviewViewmodel>.reactive(
       viewModelBuilder: () => ReviewViewmodel(),
-      onViewModelReady: (model) => model.initChallenge(challenge),
+      onViewModelReady: (model) => model.initChallenge(challenge, context),
       builder: (context, model, child) {
         return Scaffold(
           backgroundColor: FccColors.gray90,
@@ -44,14 +41,14 @@ class ReviewView extends StatelessWidget {
                   title: challenge.title,
                   child: Column(
                     children: [
-                      ...parser.parse(
-                        challenge.instructions,
-                        fontColor: FccColors.gray05,
-                      ),
-                      ...parser.parse(
-                        challenge.description,
-                        fontColor: FccColors.gray05,
-                      ),
+                      if (model.parsedInstructions != null)
+                        ...model.parsedInstructions!
+                      else
+                        const SizedBox.shrink(),
+                      if (model.parsedDescription != null)
+                        ...model.parsedDescription!
+                      else
+                        const SizedBox.shrink(),
                     ],
                   ),
                 ),

--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
@@ -41,14 +41,8 @@ class ReviewView extends StatelessWidget {
                   title: challenge.title,
                   child: Column(
                     children: [
-                      if (model.parsedInstructions != null)
-                        ...model.parsedInstructions!
-                      else
-                        const SizedBox.shrink(),
-                      if (model.parsedDescription != null)
-                        ...model.parsedDescription!
-                      else
-                        const SizedBox.shrink(),
+                      ...model.parsedInstructions,
+                      ...model.parsedDescription,
                     ],
                   ),
                 ),

--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_viewmodel.dart
@@ -12,18 +12,18 @@ class ReviewViewmodel extends BaseViewModel {
 
   final LearnService learnService = locator<LearnService>();
 
-  List<Widget>? _parsedInstructions;
-  List<Widget>? get parsedInstructions => _parsedInstructions;
+  List<Widget> _parsedInstructions = [];
+  List<Widget> get parsedInstructions => _parsedInstructions;
 
-  List<Widget>? _parsedDescription;
-  List<Widget>? get parsedDescription => _parsedDescription;
+  List<Widget> _parsedDescription = [];
+  List<Widget> get parsedDescription => _parsedDescription;
 
-  set setParsedInstructions(List<Widget>? widgets) {
+  set setParsedInstructions(List<Widget> widgets) {
     _parsedInstructions = widgets;
     notifyListeners();
   }
 
-  set setParsedDescription(List<Widget>? widgets) {
+  set setParsedDescription(List<Widget> widgets) {
     _parsedDescription = widgets;
     notifyListeners();
   }

--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_viewmodel.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/widgets.dart';
 import 'package:freecodecamp/app/app.locator.dart';
 import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
+import 'package:freecodecamp/ui/theme/fcc_theme.dart';
+import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
 import 'package:stacked/stacked.dart';
 
 class ReviewViewmodel extends BaseViewModel {
@@ -8,6 +11,22 @@ class ReviewViewmodel extends BaseViewModel {
   List<bool> get assignmentsStatus => _assignmentsStatus;
 
   final LearnService learnService = locator<LearnService>();
+
+  List<Widget>? _parsedInstructions;
+  List<Widget>? get parsedInstructions => _parsedInstructions;
+
+  List<Widget>? _parsedDescription;
+  List<Widget>? get parsedDescription => _parsedDescription;
+
+  set setParsedInstructions(List<Widget>? widgets) {
+    _parsedInstructions = widgets;
+    notifyListeners();
+  }
+
+  set setParsedDescription(List<Widget>? widgets) {
+    _parsedDescription = widgets;
+    notifyListeners();
+  }
 
   set setAssignmentsStatus(List<bool> status) {
     _assignmentsStatus = status;
@@ -20,10 +39,22 @@ class ReviewViewmodel extends BaseViewModel {
     notifyListeners();
   }
 
-  void initChallenge(Challenge challenge) {
+  void initChallenge(Challenge challenge, BuildContext context) {
+    final parser = HTMLParser(context: context);
+
     setAssignmentsStatus = List.filled(
       challenge.assignments?.length ?? 0,
       false,
+    );
+
+    setParsedInstructions = parser.parse(
+      challenge.instructions,
+      fontColor: FccColors.gray05,
+    );
+
+    setParsedDescription = parser.parse(
+      challenge.description,
+      fontColor: FccColors.gray05,
     );
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

We now display code blocks with PhoneIDE, and apparently it is more expensive to rebuild the UI when PhoneIDE involves and the UI shifts / jumps when a rebuild happens.

Instead of calling `parser.parse()` every time the UI rebuilds, I'm creating the content once during initialization and use that for the display.

<details>
<summary>Screen recording</summary>

| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/802450c9-e6c9-458a-a8d5-c79515c81b96 | https://github.com/user-attachments/assets/e36c3538-5d06-4312-a860-93575401c00b |
</details>

<!-- Feel free to add any additional description of changes below this line -->
