### PR TITLE
fix(view): remove extra space from grid blocks

### DIFF
--- a/mobile-app/lib/ui/views/learn/superblock/superblock_view.dart
+++ b/mobile-app/lib/ui/views/learn/superblock/superblock_view.dart
@@ -35,7 +35,10 @@ class SuperBlockView extends StatelessWidget {
       },
       builder: (context, model, child) => Scaffold(
         appBar: AppBar(
-          title: Text(superBlockName),
+          title: SingleChildScrollView(
+            scrollDirection: Axis.horizontal,
+            child: Text(superBlockName),
+          ),
         ),
         backgroundColor: const Color.fromRGBO(0x0a, 0x0a, 0x23, 1),
         body: FutureBuilder<SuperBlock>(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

In #1565, we changed the super block view to use the Column widget to render a custom app bar, which allows the super block title to expand rather than truncated. However, the change also results some extra space in the block display, and I'm not able to fix it.

<details>
<summary>Screenshots of the issue</summary>

<img width="390" alt="Screenshot 2025-06-27 at 18 06 15" src="https://github.com/user-attachments/assets/42df47c1-209d-4e67-91bc-540fabadbbd2" />

<img width="387" alt="Screenshot 2025-06-27 at 18 06 27" src="https://github.com/user-attachments/assets/f32de1b3-846a-4e31-9337-8fa259eaa06b" />

</details>

I think original issue (text truncation) is pretty minor and we don't need to spend too much time on this. So, um, I'm reverting the changes and going with making the appbar horizontally scrollable.

<!-- Feel free to add any additional description of changes below this line -->
