### PR TITLE
fix(dependencies): algolia_helper_flutter dependency issue

### DIFF
--- a/mobile-app/pubspec.lock
+++ b/mobile-app/pubspec.lock
@@ -50,10 +50,10 @@ packages:
     dependency: "direct main"
     description:
       name: algolia_helper_flutter
-      sha256: a1184985d8fd613fd70ee2e3fd0ae5ed61286d87f7f13e89656ed050a650fd97
+      sha256: "95e99a9e9cc6dbb89a9d00b2966354735bcc6ac2b371311311cc83653e36a028"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   algolia_insights:
     dependency: transitive
     description:

--- a/mobile-app/pubspec.yaml
+++ b/mobile-app/pubspec.yaml
@@ -5,7 +5,7 @@ version: 5.0.3+50003
 environment:
   sdk: ">=3.0.0 <4.0.0"
 dependencies:
-  algolia_helper_flutter: 1.2.0
+  algolia_helper_flutter: 1.2.1
   audio_service: 0.18.18
   auth0_flutter: 1.9.0
   cached_network_image: 3.4.1


### PR DESCRIPTION
This fixes the dependency issue from last month. Algolia search should now work again correctly when not having the correct version cached.
https://github.com/algolia/algoliasearch-helper-flutter/commit/99376f83898c6484461f09bec454d90ff91f19b9