### PR TITLE
chore(view): remove close button from pass widget

### DIFF
--- a/mobile-app/lib/ui/views/learn/widgets/pass/pass_widget_view.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/pass/pass_widget_view.dart
@@ -40,18 +40,6 @@ class PassWidgetView extends StatelessWidget {
                     ),
                   ),
                 ),
-                Expanded(
-                  child: Container(
-                    alignment: Alignment.centerRight,
-                    child: IconButton(
-                      onPressed: () {
-                        challengeModel.setShowPanel = false;
-                      },
-                      icon: const Icon(Icons.clear_sharp),
-                      iconSize: 40,
-                    ),
-                  ),
-                )
               ],
             ),
             Expanded(


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Removes the close button from the PassWidgetView. The widget is now placed in an end drawer, so users can just swipe or tap outside to close it
- Closes #1589

<details>
<summary>Screenshot</summary>

<img width="397" alt="Screenshot 2025-07-04 at 03 55 06" src="https://github.com/user-attachments/assets/e0c0dd22-0dcb-466d-8ab4-0cc9ad6a1205" />

</details>

<!-- Feel free to add any additional description of changes below this line -->
