### PR TITLE
fix: learn file controller test

### DIFF
--- a/mobile-app/test/unit/learn_file_controller_test.dart
+++ b/mobile-app/test/unit/learn_file_controller_test.dart
@@ -277,7 +277,7 @@ void main() {
 
   group('parseJsDocumentsAsScriptTags function', () {
     testWidgets(
-        'it should inject script content if JS file is linked when babelController is null',
+        'it should throw an error if JS file is linked when babelController is null',
         (tester) async {
       Challenge jsChallenge = Challenge(
         id: '4',
@@ -313,9 +313,10 @@ void main() {
         ],
       );
       String html = jsChallenge.files[0].contents;
-      String result = await service
-          .parseJsDocumentsAsScriptTags(jsChallenge, html, null, testing: true);
-      expect(result, contains('console.log("hello");'));
+      expect(
+        () async => await service.parseJsDocumentsAsScriptTags(jsChallenge, html, null, testing: true),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'description', contains('Babel controller is required to transpile JS code.'))),
+      );
     });
   });
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

I recently added unit tests for `parseJsDocumentsAsScriptTags` (#1592) but this conflicted with #1569 as the PR changes how the function handles `babelController == null`, and it's causing tests to fail (https://github.com/freeCodeCamp/mobile/actions/runs/16116445353/job/45471317588?pr=1594#step:7:29).

This PR updates the test to reflect the function's change.

<!-- Feel free to add any additional description of changes below this line -->
