### PR TITLE
fix(view): handle missing challenge video

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/multiple_choice/multiple_choice_view.dart
@@ -72,6 +72,7 @@ class MultipleChoiceView extends StatelessWidget {
                     title: 'Transcript',
                     child: Transcript(
                       transcript: challenge.transcript,
+                      isCollapsible: challenge.videoId != null,
                     ),
                   ),
                 ],

--- a/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
@@ -81,6 +81,7 @@ class PythonView extends StatelessWidget {
                     title: 'Transcript',
                     child: Transcript(
                       transcript: challenge.transcript,
+                      isCollapsible: challenge.videoId != null,
                     ),
                   ),
                 ],

--- a/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/python/python_view.dart
@@ -68,12 +68,13 @@ class PythonView extends StatelessWidget {
                     ),
                   ),
                 const SizedBox(height: 12),
-                ChallengeCard(
-                  title: 'Video',
-                  child: YoutubePlayerWidget(
-                    videoId: challenge.videoId!,
+                if (challenge.videoId != null)
+                  ChallengeCard(
+                    title: 'Video',
+                    child: YoutubePlayerWidget(
+                      videoId: challenge.videoId!,
+                    ),
                   ),
-                ),
                 const SizedBox(height: 12),
                 if (challenge.transcript.isNotEmpty) ...[
                   ChallengeCard(

--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
@@ -60,6 +60,7 @@ class ReviewView extends StatelessWidget {
                     title: 'Transcript',
                     child: Transcript(
                       transcript: challenge.transcript,
+                      isCollapsible: challenge.videoId != null,
                     ),
                   ),
                 ],

--- a/mobile-app/lib/ui/views/learn/widgets/transcript_widget.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/transcript_widget.dart
@@ -5,29 +5,40 @@ class Transcript extends StatelessWidget {
   const Transcript({
     super.key,
     required this.transcript,
+    this.isCollapsible = true,
   });
 
   final String transcript;
+  final bool isCollapsible;
 
   @override
   Widget build(BuildContext context) {
     HTMLParser parser = HTMLParser(context: context);
 
-    return ExpansionTile(
-      backgroundColor: Colors.transparent,
-      collapsedBackgroundColor: Colors.transparent,
-      title: const Text('Tap to expand'),
-      shape: const RoundedRectangleBorder(
-        side: BorderSide.none,
-        borderRadius: BorderRadius.zero,
-      ),
-      collapsedShape: const RoundedRectangleBorder(
-        side: BorderSide.none,
-        borderRadius: BorderRadius.zero,
-      ),
-      children: [
-        ...parser.parse(transcript),
-      ],
-    );
+    if (isCollapsible) {
+      return ExpansionTile(
+        backgroundColor: Colors.transparent,
+        collapsedBackgroundColor: Colors.transparent,
+        title: const Text('Tap to expand'),
+        shape: const RoundedRectangleBorder(
+          side: BorderSide.none,
+          borderRadius: BorderRadius.zero,
+        ),
+        collapsedShape: const RoundedRectangleBorder(
+          side: BorderSide.none,
+          borderRadius: BorderRadius.zero,
+        ),
+        children: [
+          ...parser.parse(transcript),
+        ],
+      );
+    } else {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          ...parser.parse(transcript),
+        ],
+      );
+    }
   }
 }


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

This PR:
- Updates `PythonView` to handle missing video
- Updates `Transcript` widget to accept an `isCollapsible` boolean. It should be collapsible when there is a video, otherwise the transcript is displayed as plain text
- Closes #1616

<!-- Feel free to add any additional description of changes below this line -->
