### PR TITLE
fix: flip instructions and descriptions in multiple views

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/english/english_view.dart
@@ -45,14 +45,14 @@ class EnglishView extends StatelessWidget {
                   child: Column(
                     children: [
                       ...parser.parse(
-                        challenge.instructions,
+                        challenge.description,
                         customStyles: {
                           '*:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)':
                               Style(color: FccColors.gray05),
                         },
                       ),
                       ...parser.parse(
-                        challenge.description,
+                        challenge.instructions,
                         customStyles: {
                           '*:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)':
                               Style(color: FccColors.gray05),

--- a/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/quiz/quiz_view.dart
@@ -86,14 +86,14 @@ class QuizView extends StatelessWidget {
                     child: Column(
                       children: [
                         ...parser.parse(
-                          challenge.instructions,
+                          challenge.description,
                           customStyles: {
                             '*:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)':
                                 Style(color: FccColors.gray05),
                           },
                         ),
                         ...parser.parse(
-                          challenge.description,
+                          challenge.instructions,
                           customStyles: {
                             '*:not(h1):not(h2):not(h3):not(h4):not(h5):not(h6)':
                                 Style(color: FccColors.gray05),

--- a/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/review/review_view.dart
@@ -40,8 +40,8 @@ class ReviewView extends StatelessWidget {
                   title: challenge.title,
                   child: Column(
                     children: [
-                      ...model.parsedInstructions,
                       ...model.parsedDescription,
+                      ...model.parsedInstructions,
                     ],
                   ),
                 ),


### PR DESCRIPTION
- **fix(view): swap challenge instructions and description in English and Quiz views**
- **fix(view): swap parsed instructions and description in ReviewView**

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #1645

<!-- Feel free to add any additional description of changes below this line -->
