### PR TITLE
fix: notification permission context crash on startup

### DIFF
--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -50,14 +50,13 @@ Future<void> main({bool testing = false}) async {
     }
   }
   await RemoteConfigService().init();
-  await NotificationService().init();
-  await DailyChallengeNotificationService().init();
+  await locator<NotificationService>().init();
+  await locator<DailyChallengeNotificationService>().init();
 
   runApp(const FreeCodeCampMobileApp());
-
   WidgetsBinding.instance.addPostFrameCallback((_) async {
-    await NotificationService().requestPermission();
-    await DailyChallengeNotificationService().setupNotifications();
+    await locator<NotificationService>().requestPermission();
+    await locator<DailyChallengeNotificationService>().setupNotifications();
   });
 
   await QuickActionsService().init();

--- a/mobile-app/lib/service/learn/daily_challenge_notification_service.dart
+++ b/mobile-app/lib/service/learn/daily_challenge_notification_service.dart
@@ -1,6 +1,8 @@
+import 'dart:developer' as developer;
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:freecodecamp/app/app.locator.dart';
 import 'package:freecodecamp/models/learn/completed_challenge_model.dart';
@@ -51,9 +53,73 @@ class DailyChallengeNotificationService {
     );
   }
 
-  Future<void> setupNotifications() async {
-    final permissionGranted = await areSystemNotificationsEnabled();
+  Future<bool> requestPermissionIfNeeded() async {
+    if (Platform.isAndroid) {
+      final androidImplementation = _flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
 
+      if (androidImplementation == null) {
+        return false;
+      }
+
+      try {
+        return await androidImplementation.requestNotificationsPermission() ??
+            false;
+      } on PlatformException catch (e, stackTrace) {
+        developer.log(
+          'Failed to request Android notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      } catch (e, stackTrace) {
+        developer.log(
+          'Unexpected failure while requesting Android notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      }
+    }
+
+    if (Platform.isIOS) {
+      final iosImplementation = _flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>();
+
+      try {
+        return await iosImplementation?.requestPermissions(
+              alert: true,
+              badge: true,
+              sound: true,
+            ) ??
+            false;
+      } on PlatformException catch (e, stackTrace) {
+        developer.log(
+          'Failed to request iOS notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      } catch (e, stackTrace) {
+        developer.log(
+          'Unexpected failure while requesting iOS notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  Future<void> setupNotifications() async {
+    final permissionGranted = await requestPermissionIfNeeded();
+
+    // Auto-enable daily notifications if system permission is granted
+    // and user hasn't explicitly disabled them
     if (permissionGranted) {
       final prefs = await SharedPreferences.getInstance();
       final hasSetPreference =
@@ -68,6 +134,8 @@ class DailyChallengeNotificationService {
       }
     }
   }
+
+  Future<void> requestPermissionAndConfigure() => setupNotifications();
 
   void _onNotificationResponse(NotificationResponse response) {
     if (response.payload == 'daily_challenge_notification') {
@@ -103,7 +171,27 @@ class DailyChallengeNotificationService {
       final androidImplementation = _flutterLocalNotificationsPlugin
           .resolvePlatformSpecificImplementation<
               AndroidFlutterLocalNotificationsPlugin>();
-      return await androidImplementation?.areNotificationsEnabled() ?? false;
+      if (androidImplementation == null) {
+        return false;
+      }
+
+      try {
+        return await androidImplementation.areNotificationsEnabled() ?? false;
+      } on PlatformException catch (e, stackTrace) {
+        developer.log(
+          'Failed to check Android notification permission state.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      } catch (e, stackTrace) {
+        developer.log(
+          'Unexpected failure while checking Android notification permission state.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      }
     }
 
     // iOS does not let apps check notification status after permission is granted, so we always return true.

--- a/mobile-app/lib/service/podcast/notification_service.dart
+++ b/mobile-app/lib/service/podcast/notification_service.dart
@@ -1,6 +1,8 @@
+import 'dart:developer' as developer;
 import 'dart:io';
 import 'dart:math';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 
 // This is a singleton class and initialized only once
@@ -32,14 +34,66 @@ class NotificationService {
 
   Future<bool> requestPermission() async {
     if (Platform.isAndroid) {
-      return await _flutterLocalNotificationsPlugin
-              .resolvePlatformSpecificImplementation<
-                  AndroidFlutterLocalNotificationsPlugin>()
-              ?.requestNotificationsPermission() ??
-          false;
+      final androidImplementation = _flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+
+      if (androidImplementation == null) {
+        return false;
+      }
+
+      try {
+        return await androidImplementation.requestNotificationsPermission() ??
+            false;
+      } on PlatformException catch (e, stackTrace) {
+        developer.log(
+          'Failed to request Android notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      } catch (e, stackTrace) {
+        developer.log(
+          'Unexpected failure while requesting Android notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      }
+    }
+
+    if (Platform.isIOS) {
+      final iosImplementation = _flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              IOSFlutterLocalNotificationsPlugin>();
+
+      try {
+        return await iosImplementation?.requestPermissions(
+              alert: true,
+              badge: true,
+              sound: true,
+            ) ??
+            false;
+      } on PlatformException catch (e, stackTrace) {
+        developer.log(
+          'Failed to request iOS notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      } catch (e, stackTrace) {
+        developer.log(
+          'Unexpected failure while requesting iOS notification permission.',
+          error: e,
+          stackTrace: stackTrace,
+        );
+        return false;
+      }
     }
     return true;
   }
+
+  Future<bool> requestPermissionIfNeeded() => requestPermission();
 
   Future<void> showNotification(String title, String body) async {
     // Check up more on the below values here


### PR DESCRIPTION
## Summary
- defer notification permission requests until after first frame so Android activity/context is attached
- split plugin initialization from permission prompting in both notification services
- add defensive exception handling around Android/iOS permission calls and Android notification-state checks

## Testing
- flutter test test/services/learn/daily_challenge_notification_service_test.dart
- flutter analyze lib/main.dart lib/service/podcast/notification_service.dart lib/service/learn/daily_challenge_notification_service.dart