### PR TITLE
Remove back button in Preview and Console views

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -94,7 +94,10 @@ class ChallengeView extends StatelessWidget {
     BuildContext context,
     ChallengeViewModel model,
   ) {
+    final bool isPreviewOrConsole = model.showPreview || model.showConsole;
+
     return AppBar(
+      automaticallyImplyLeading: !isPreviewOrConsole,
       actions: <Widget>[
         Container(),
       ],


### PR DESCRIPTION
## Summary
- hide the AppBar back button when challenge view is in Preview mode
- hide the AppBar back button when challenge view is in Console mode
- keep default back button behavior for other challenge view states

## Testing
- flutter analyze
