### PR TITLE
Use headless test runner and avoid drawer rebuild churn

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -72,7 +72,12 @@ class ChallengeView extends StatelessWidget {
             model,
             maxChallenges,
           ),
-          onEndDrawerChanged: (isOpened) => model.setShowPanel = isOpened,
+          onEndDrawerChanged: (isOpened) {
+            model.syncShowPanel(isOpened);
+            if (isOpened) {
+              FocusManager.instance.primaryFocus?.unfocus();
+            }
+          },
           bottomNavigationBar: _buildBottomBar(
             context,
             model,
@@ -556,8 +561,18 @@ class ChallengeView extends StatelessWidget {
           if (model.panelType != PanelType.instruction) {
             model.setPanelType = PanelType.instruction;
           }
-          model.setShowPanel = !model.showPanel;
-          model.scaffoldKey.currentState?.openEndDrawer();
+          final scaffoldState = model.scaffoldKey.currentState;
+          if (scaffoldState == null) {
+            return;
+          }
+
+          if (scaffoldState.isEndDrawerOpen) {
+            model.setShowPanel = false;
+            scaffoldState.closeEndDrawer();
+          } else {
+            model.setShowPanel = true;
+            scaffoldState.openEndDrawer();
+          }
         },
       ),
       if (!noPreviewChallengeTypes.contains(challenge.challengeType))

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -1,15 +1,11 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:freecodecamp/enums/panel_type.dart';
 import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/models/learn/daily_challenge_model.dart';
 import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/challenge_viewmodel.dart';
-import 'package:freecodecamp/ui/views/learn/test_runner.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/project_preview.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/symbol_bar.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/console/console_view.dart';
@@ -267,52 +263,6 @@ class ChallengeView extends StatelessWidget {
             ),
           Row(
             children: [
-              SizedBox(
-                height: 1,
-                width: 1,
-                child: InAppWebView(
-                  initialData: InAppWebViewInitialData(
-                    data:
-                        '<html><head><title>Test Runner</title></head><body></body></html>',
-                    mimeType: 'text/html',
-                    baseUrl: WebUri('http://localhost:8080/test-runner'),
-                  ),
-                  onWebViewCreated: (controller) {
-                    model.setTestController = controller;
-                  },
-                  onConsoleMessage: (controller, console) {
-                    if (console.messageLevel == ConsoleMessageLevel.LOG) {
-                      model.setUserConsoleMessages = [
-                        ...model.userConsoleMessages,
-                        '<p>${console.message}</p>',
-                      ];
-                    }
-                  },
-                  onLoadStop: (controller, url) async {
-                    ScriptBuilder builder = ScriptBuilder();
-                    final res = await controller.callAsyncJavaScript(
-                      functionBody: ScriptBuilder.runnerScript,
-                      arguments: {
-                        'userCode': '',
-                        'workerType':
-                            builder.getWorkerType(challenge.challengeType),
-                        'combinedCode': '',
-                        'editableRegionContent': '',
-                        'hooks': {
-                          'beforeAll': '',
-                          'beforeEach': '',
-                          'afterEach': '',
-                        },
-                      },
-                    );
-                    log('TestRunner: $res');
-                  },
-                  initialSettings: InAppWebViewSettings(
-                    isInspectable: true,
-                    mediaPlaybackRequiresUserGesture: false,
-                  ),
-                ),
-              ),
               ..._panelIconButtons(
                 model,
                 challenge,

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -213,8 +213,13 @@ class ChallengeViewModel extends BaseViewModel {
   }
 
   set setShowPanel(bool value) {
+    if (_showPanel == value) return;
     _showPanel = value;
     notifyListeners();
+  }
+
+  void syncShowPanel(bool value) {
+    _showPanel = value;
   }
 
   set setWebviewController(InAppWebViewController value) {

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -123,6 +123,47 @@ class ChallengeViewModel extends BaseViewModel {
       isInspectable: true,
     ),
   );
+  late final HeadlessInAppWebView _testRunnerWebView = HeadlessInAppWebView(
+    initialData: InAppWebViewInitialData(
+      data: '<html><head><title>Test Runner</title></head><body></body></html>',
+      mimeType: 'text/html',
+      baseUrl: WebUri('http://localhost:8080/test-runner'),
+    ),
+    onWebViewCreated: (controller) {
+      _testController = controller;
+    },
+    onConsoleMessage: (controller, console) {
+      if (console.messageLevel == ConsoleMessageLevel.LOG) {
+        setUserConsoleMessages = [
+          ...userConsoleMessages,
+          '<p>${console.message}</p>',
+        ];
+      }
+    },
+    onLoadStop: (controller, url) async {
+      ScriptBuilder builder = ScriptBuilder();
+      final res = await controller.callAsyncJavaScript(
+        functionBody: ScriptBuilder.runnerScript,
+        arguments: {
+          'userCode': '',
+          'workerType': builder.getWorkerType(challenge?.challengeType ?? 0),
+          'combinedCode': '',
+          'editableRegionContent': '',
+          'hooks': {
+            'beforeAll': '',
+            'beforeEach': '',
+            'afterEach': '',
+          },
+        },
+      );
+      log('TestRunner: $res');
+    },
+    initialSettings: InAppWebViewSettings(
+      isInspectable: true,
+      mediaPlaybackRequiresUserGesture: false,
+    ),
+  );
+  bool _webViewsClosed = false;
 
   bool _mounted = false;
   bool get mounted => _mounted;
@@ -168,11 +209,6 @@ class ChallengeViewModel extends BaseViewModel {
 
   set setEditableRegionContent(String value) {
     _editableRegionContent = value;
-    notifyListeners();
-  }
-
-  set setTestController(InAppWebViewController controller) {
-    _testController = controller;
     notifyListeners();
   }
 
@@ -298,9 +334,6 @@ class ChallengeViewModel extends BaseViewModel {
     required Challenge challenge,
     required DateTime? challengeDate,
   }) async {
-    await _babelWebView.run();
-    await _localhostServer.start();
-
     _challengeDate = challengeDate;
     _isDailyChallenge = challengeDate != null;
 
@@ -312,6 +345,13 @@ class ChallengeViewModel extends BaseViewModel {
 
     setChallenge = challenge;
     setBlock = block;
+
+    if (_webViewsClosed) return;
+    await _localhostServer.start();
+    if (_webViewsClosed) return;
+    await _babelWebView.run();
+    if (_webViewsClosed) return;
+    await _testRunnerWebView.run();
 
     listenToSymbolBarScrollController();
   }
@@ -340,8 +380,24 @@ class ChallengeViewModel extends BaseViewModel {
   }
 
   void closeWebViews() async {
-    await _babelWebView.dispose();
-    await _localhostServer.close();
+    if (_webViewsClosed) return;
+    _webViewsClosed = true;
+
+    try {
+      await _testRunnerWebView.dispose();
+    } catch (e) {
+      log('Test runner dispose error: $e');
+    }
+    try {
+      await _babelWebView.dispose();
+    } catch (e) {
+      log('Babel dispose error: $e');
+    }
+    try {
+      await _localhostServer.close();
+    } catch (e) {
+      log('Localhost server close error: $e');
+    }
   }
 
   void initFile(
@@ -731,8 +787,19 @@ class ChallengeViewModel extends BaseViewModel {
       return;
     }
 
+    InAppWebViewController? runnerController = testController;
+    if (runnerController == null) {
+      setTestConsoleMessages = [
+        ...testConsoleMessages,
+        '<p>Test runner is still initializing. Please try again.</p>',
+        '<p>// tests completed</p>',
+      ];
+      setIsRunningTests = false;
+      return;
+    }
+
     if ([1, 26, 28].contains(challenge!.challengeType)) {
-      final evalResult = await testController!.callAsyncJavaScript(
+      final evalResult = await runnerController.callAsyncJavaScript(
         functionBody: userCode,
       );
       if (evalResult != null && evalResult.error != null) {
@@ -744,9 +811,7 @@ class ChallengeViewModel extends BaseViewModel {
       }
     }
 
-    // TODO: Handle the case when the test runner is not created
-    // ignore: unused_local_variable
-    final updateTestRunnerRes = await testController!.callAsyncJavaScript(
+    await runnerController.callAsyncJavaScript(
       functionBody: ScriptBuilder.runnerScript,
       arguments: {
         'userCode': userCode,
@@ -763,7 +828,7 @@ class ChallengeViewModel extends BaseViewModel {
 
     for (int i = 0; i < challenge!.tests.length; i++) {
       ChallengeTest test = challenge!.tests[i];
-      final testRes = await testController!.callAsyncJavaScript(
+      final testRes = await runnerController.callAsyncJavaScript(
         functionBody: ScriptBuilder.testExecutionScript,
         arguments: {
           'testStr': test.javaScript,


### PR DESCRIPTION
## Summary
- replace the mounted 1x1 challenge test runner `InAppWebView` with a `HeadlessInAppWebView`
- move test-runner setup into `ChallengeViewModel` lifecycle and guard test execution while initialization is in progress
- stop drawer drag open/close from triggering reactive rebuilds of the challenge view
- keep info-panel button behavior explicit by toggling the drawer from scaffold state

## Why
The test runner relied on a hidden widget in the tree and drawer drag gestures were causing unnecessary rebuilds of panel content.

## Impact
- cleaner test-runner lifecycle without a hidden rendered webview
- improved stability when tests are triggered early
- smoother drawer interaction with less rebuild churn

## Validation
- `flutter analyze lib/ui/views/learn/challenge/challenge_view.dart lib/ui/views/learn/challenge/challenge_viewmodel.dart`
