### PR TITLE
fix(challenge): use headless in-app webview for test runner

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -1,15 +1,11 @@
-import 'dart:developer';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
-import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:freecodecamp/enums/panel_type.dart';
 import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/models/learn/daily_challenge_model.dart';
 import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/challenge_viewmodel.dart';
-import 'package:freecodecamp/ui/views/learn/test_runner.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/project_preview.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/symbol_bar.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/console/console_view.dart';
@@ -267,52 +263,6 @@ class ChallengeView extends StatelessWidget {
             ),
           Row(
             children: [
-              SizedBox(
-                height: 1,
-                width: 1,
-                child: InAppWebView(
-                  initialData: InAppWebViewInitialData(
-                    data:
-                        '<html><head><title>Test Runner</title></head><body></body></html>',
-                    mimeType: 'text/html',
-                    baseUrl: WebUri('http://localhost:8080/test-runner'),
-                  ),
-                  onWebViewCreated: (controller) {
-                    model.setTestController = controller;
-                  },
-                  onConsoleMessage: (controller, console) {
-                    if (console.messageLevel == ConsoleMessageLevel.LOG) {
-                      model.setUserConsoleMessages = [
-                        ...model.userConsoleMessages,
-                        '<p>${console.message}</p>',
-                      ];
-                    }
-                  },
-                  onLoadStop: (controller, url) async {
-                    ScriptBuilder builder = ScriptBuilder();
-                    final res = await controller.callAsyncJavaScript(
-                      functionBody: ScriptBuilder.runnerScript,
-                      arguments: {
-                        'userCode': '',
-                        'workerType':
-                            builder.getWorkerType(challenge.challengeType),
-                        'combinedCode': '',
-                        'editableRegionContent': '',
-                        'hooks': {
-                          'beforeAll': '',
-                          'beforeEach': '',
-                          'afterEach': '',
-                        },
-                      },
-                    );
-                    log('TestRunner: $res');
-                  },
-                  initialSettings: InAppWebViewSettings(
-                    isInspectable: true,
-                    mediaPlaybackRequiresUserGesture: false,
-                  ),
-                ),
-              ),
               ..._panelIconButtons(
                 model,
                 challenge,

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -163,6 +163,7 @@ class ChallengeViewModel extends BaseViewModel {
       mediaPlaybackRequiresUserGesture: false,
     ),
   );
+  bool _closingWebViews = false;
   bool _webViewsClosed = false;
 
   bool _mounted = false;
@@ -346,14 +347,27 @@ class ChallengeViewModel extends BaseViewModel {
     setChallenge = challenge;
     setBlock = block;
 
-    if (_webViewsClosed) return;
-    await _localhostServer.start();
-    if (_webViewsClosed) return;
-    await _babelWebView.run();
-    if (_webViewsClosed) return;
-    await _testRunnerWebView.run();
+    final webViewsStarted = await _startWebViews();
+    if (!webViewsStarted) return;
 
     listenToSymbolBarScrollController();
+  }
+
+  bool get _shouldStopWebViewSetup => _closingWebViews || _webViewsClosed;
+
+  Future<bool> _startWebViews() async {
+    final setupSteps = [
+      _localhostServer.start,
+      _babelWebView.run,
+      _testRunnerWebView.run,
+    ];
+
+    for (final setupStep in setupSteps) {
+      if (_shouldStopWebViewSetup) return false;
+      await setupStep();
+    }
+
+    return !_shouldStopWebViewSetup;
   }
 
   Future<void> setSelectedDailyChallengeLanguage(
@@ -380,8 +394,8 @@ class ChallengeViewModel extends BaseViewModel {
   }
 
   void closeWebViews() async {
-    if (_webViewsClosed) return;
-    _webViewsClosed = true;
+    if (_closingWebViews || _webViewsClosed) return;
+    _closingWebViews = true;
 
     try {
       await _testRunnerWebView.dispose();
@@ -398,6 +412,9 @@ class ChallengeViewModel extends BaseViewModel {
     } catch (e) {
       log('Localhost server close error: $e');
     }
+
+    _webViewsClosed = true;
+    _closingWebViews = false;
   }
 
   void initFile(

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -123,6 +123,47 @@ class ChallengeViewModel extends BaseViewModel {
       isInspectable: true,
     ),
   );
+  late final HeadlessInAppWebView _testRunnerWebView = HeadlessInAppWebView(
+    initialData: InAppWebViewInitialData(
+      data: '<html><head><title>Test Runner</title></head><body></body></html>',
+      mimeType: 'text/html',
+      baseUrl: WebUri('http://localhost:8080/test-runner'),
+    ),
+    onWebViewCreated: (controller) {
+      _testController = controller;
+    },
+    onConsoleMessage: (controller, console) {
+      if (console.messageLevel == ConsoleMessageLevel.LOG) {
+        setUserConsoleMessages = [
+          ...userConsoleMessages,
+          '<p>${console.message}</p>',
+        ];
+      }
+    },
+    onLoadStop: (controller, url) async {
+      ScriptBuilder builder = ScriptBuilder();
+      final res = await controller.callAsyncJavaScript(
+        functionBody: ScriptBuilder.runnerScript,
+        arguments: {
+          'userCode': '',
+          'workerType': builder.getWorkerType(challenge?.challengeType ?? 0),
+          'combinedCode': '',
+          'editableRegionContent': '',
+          'hooks': {
+            'beforeAll': '',
+            'beforeEach': '',
+            'afterEach': '',
+          },
+        },
+      );
+      log('TestRunner: $res');
+    },
+    initialSettings: InAppWebViewSettings(
+      isInspectable: true,
+      mediaPlaybackRequiresUserGesture: false,
+    ),
+  );
+  bool _webViewsClosed = false;
 
   bool _mounted = false;
   bool get mounted => _mounted;
@@ -168,11 +209,6 @@ class ChallengeViewModel extends BaseViewModel {
 
   set setEditableRegionContent(String value) {
     _editableRegionContent = value;
-    notifyListeners();
-  }
-
-  set setTestController(InAppWebViewController controller) {
-    _testController = controller;
     notifyListeners();
   }
 
@@ -298,9 +334,6 @@ class ChallengeViewModel extends BaseViewModel {
     required Challenge challenge,
     required DateTime? challengeDate,
   }) async {
-    await _babelWebView.run();
-    await _localhostServer.start();
-
     _challengeDate = challengeDate;
     _isDailyChallenge = challengeDate != null;
 
@@ -312,6 +345,13 @@ class ChallengeViewModel extends BaseViewModel {
 
     setChallenge = challenge;
     setBlock = block;
+
+    if (_webViewsClosed) return;
+    await _localhostServer.start();
+    if (_webViewsClosed) return;
+    await _babelWebView.run();
+    if (_webViewsClosed) return;
+    await _testRunnerWebView.run();
 
     listenToSymbolBarScrollController();
   }
@@ -340,8 +380,24 @@ class ChallengeViewModel extends BaseViewModel {
   }
 
   void closeWebViews() async {
-    await _babelWebView.dispose();
-    await _localhostServer.close();
+    if (_webViewsClosed) return;
+    _webViewsClosed = true;
+
+    try {
+      await _testRunnerWebView.dispose();
+    } catch (e) {
+      log('Test runner dispose error: $e');
+    }
+    try {
+      await _babelWebView.dispose();
+    } catch (e) {
+      log('Babel dispose error: $e');
+    }
+    try {
+      await _localhostServer.close();
+    } catch (e) {
+      log('Localhost server close error: $e');
+    }
   }
 
   void initFile(
@@ -731,8 +787,19 @@ class ChallengeViewModel extends BaseViewModel {
       return;
     }
 
+    InAppWebViewController? runnerController = testController;
+    if (runnerController == null) {
+      setTestConsoleMessages = [
+        ...testConsoleMessages,
+        '<p>Test runner is still initializing. Please try again.</p>',
+        '<p>// tests completed</p>',
+      ];
+      setIsRunningTests = false;
+      return;
+    }
+
     if ([1, 26, 28].contains(challenge!.challengeType)) {
-      final evalResult = await testController!.callAsyncJavaScript(
+      final evalResult = await runnerController.callAsyncJavaScript(
         functionBody: userCode,
       );
       if (evalResult != null && evalResult.error != null) {
@@ -744,9 +811,7 @@ class ChallengeViewModel extends BaseViewModel {
       }
     }
 
-    // TODO: Handle the case when the test runner is not created
-    // ignore: unused_local_variable
-    final updateTestRunnerRes = await testController!.callAsyncJavaScript(
+    await runnerController.callAsyncJavaScript(
       functionBody: ScriptBuilder.runnerScript,
       arguments: {
         'userCode': userCode,
@@ -763,7 +828,7 @@ class ChallengeViewModel extends BaseViewModel {
 
     for (int i = 0; i < challenge!.tests.length; i++) {
       ChallengeTest test = challenge!.tests[i];
-      final testRes = await testController!.callAsyncJavaScript(
+      final testRes = await runnerController.callAsyncJavaScript(
         functionBody: ScriptBuilder.testExecutionScript,
         arguments: {
           'testStr': test.javaScript,


### PR DESCRIPTION
## Summary
- replace the hidden 1x1 challenge test runner `InAppWebView` with a `HeadlessInAppWebView`
- move test runner initialization into `ChallengeViewModel` lifecycle
- guard test execution when the test runner is still initializing
- make webview disposal idempotent

## Why
The challenge runner depended on a hidden rendered widget instead of a true headless runtime, which made lifecycle handling more fragile.

## Validation
- `flutter analyze lib/ui/views/learn/challenge/challenge_view.dart lib/ui/views/learn/challenge/challenge_viewmodel.dart`
