### PR TITLE
fix(challenge): prevent drawer content rebuild on swipe

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -76,7 +76,12 @@ class ChallengeView extends StatelessWidget {
             model,
             maxChallenges,
           ),
-          onEndDrawerChanged: (isOpened) => model.setShowPanel = isOpened,
+          onEndDrawerChanged: (isOpened) {
+            model.syncShowPanel(isOpened);
+            if (isOpened) {
+              FocusManager.instance.primaryFocus?.unfocus();
+            }
+          },
           bottomNavigationBar: _buildBottomBar(
             context,
             model,
@@ -606,8 +611,18 @@ class ChallengeView extends StatelessWidget {
           if (model.panelType != PanelType.instruction) {
             model.setPanelType = PanelType.instruction;
           }
-          model.setShowPanel = !model.showPanel;
-          model.scaffoldKey.currentState?.openEndDrawer();
+          final scaffoldState = model.scaffoldKey.currentState;
+          if (scaffoldState == null) {
+            return;
+          }
+
+          if (scaffoldState.isEndDrawerOpen) {
+            model.setShowPanel = false;
+            scaffoldState.closeEndDrawer();
+          } else {
+            model.setShowPanel = true;
+            scaffoldState.openEndDrawer();
+          }
         },
       ),
       if (!noPreviewChallengeTypes.contains(challenge.challengeType))

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_viewmodel.dart
@@ -177,8 +177,13 @@ class ChallengeViewModel extends BaseViewModel {
   }
 
   set setShowPanel(bool value) {
+    if (_showPanel == value) return;
     _showPanel = value;
     notifyListeners();
+  }
+
+  void syncShowPanel(bool value) {
+    _showPanel = value;
   }
 
   set setWebviewController(InAppWebViewController value) {


### PR DESCRIPTION
## Summary
- prevent end-drawer swipe open/close from triggering reactive challenge view rebuilds
- keep explicit info-panel button toggles reactive and synced with drawer state
- avoid unnecessary `notifyListeners` when `showPanel` value is unchanged

## Why
Drawer gestures were updating reactive state on each open/close cycle, which caused panel content to rebuild unnecessarily.

## Validation
- `flutter analyze lib/ui/views/learn/challenge/challenge_view.dart lib/ui/views/learn/challenge/challenge_viewmodel.dart`
