### PR TITLE
Add curriculum language selector

### DIFF
--- a/mobile-app/lib/app/app.dart
+++ b/mobile-app/lib/app/app.dart
@@ -8,6 +8,7 @@ import 'package:freecodecamp/service/learn/learn_offline_service.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
 import 'package:freecodecamp/service/learn/daily_challenge_service.dart';
 import 'package:freecodecamp/service/learn/daily_challenge_notification_service.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/service/locale_service.dart';
 import 'package:freecodecamp/service/navigation/quick_actions_service.dart';
 import 'package:freecodecamp/service/news/bookmark_service.dart';
@@ -83,6 +84,7 @@ import 'package:stacked_services/stacked_services.dart';
     LazySingleton(classType: RemoteConfigService),
     LazySingleton(classType: BookmarksDatabaseService),
     LazySingleton(classType: LocaleService),
+    LazySingleton(classType: CurriculumLanguageService),
     LazySingleton(classType: DioService),
     LazySingleton(classType: NewsApiService),
   ],

--- a/mobile-app/lib/app/app.locator.dart
+++ b/mobile-app/lib/app/app.locator.dart
@@ -20,6 +20,7 @@ import '../service/firebase/remote_config_service.dart';
 import '../service/learn/daily_challenge_notification_service.dart';
 import '../service/learn/daily_challenge_service.dart';
 import '../service/learn/learn_file_service.dart';
+import '../service/learn/curriculum_language_service.dart';
 import '../service/learn/learn_offline_service.dart';
 import '../service/learn/learn_service.dart';
 import '../service/locale_service.dart';
@@ -60,6 +61,7 @@ Future<void> setupLocator({
   locator.registerLazySingleton(() => RemoteConfigService());
   locator.registerLazySingleton(() => BookmarksDatabaseService());
   locator.registerLazySingleton(() => LocaleService());
+  locator.registerLazySingleton(() => CurriculumLanguageService());
   locator.registerLazySingleton(() => DioService());
   locator.registerLazySingleton(() => NewsApiService());
 }

--- a/mobile-app/lib/main.dart
+++ b/mobile-app/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:freecodecamp/service/authentication/authentication_service.dart'
 import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/service/firebase/analytics_service.dart';
 import 'package:freecodecamp/service/firebase/remote_config_service.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/service/learn/daily_challenge_notification_service.dart';
 import 'package:freecodecamp/service/locale_service.dart';
 import 'package:freecodecamp/service/navigation/quick_actions_service.dart';
@@ -28,6 +29,7 @@ Future<void> main({bool testing = false}) async {
   WidgetsFlutterBinding.ensureInitialized();
   setupLocator();
   locator<LocaleService>().init();
+  await locator<CurriculumLanguageService>().init();
 
   await DioService().init();
   await AppAudioService().init();

--- a/mobile-app/lib/service/learn/curriculum_language_service.dart
+++ b/mobile-app/lib/service/learn/curriculum_language_service.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:freecodecamp/service/authentication/authentication_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class CurriculumLanguage {
+  final String slug;
+  final String name;
+  const CurriculumLanguage({required this.slug, required this.name});
+}
+
+class CurriculumLanguageService {
+  static const List<CurriculumLanguage> languages = [
+    CurriculumLanguage(slug: 'english', name: 'English'),
+    CurriculumLanguage(slug: 'espanol', name: 'Spanish'),
+    CurriculumLanguage(slug: 'chinese', name: 'Chinese (Simplified)'),
+    CurriculumLanguage(
+        slug: 'chinese-traditional', name: 'Chinese (Traditional)'),
+    CurriculumLanguage(slug: 'italian', name: 'Italian'),
+    CurriculumLanguage(slug: 'portuguese', name: 'Portuguese'),
+    CurriculumLanguage(slug: 'ukrainian', name: 'Ukrainian'),
+    CurriculumLanguage(slug: 'japanese', name: 'Japanese'),
+    CurriculumLanguage(slug: 'german', name: 'German'),
+    CurriculumLanguage(slug: 'swahili', name: 'Swahili'),
+    CurriculumLanguage(slug: 'korean', name: 'Korean'),
+  ];
+
+  static const String _prefKey = 'curriculumLanguage';
+
+  CurriculumLanguage _current = languages[0];
+  CurriculumLanguage get current => _current;
+
+  final _controller = StreamController<CurriculumLanguage>.broadcast();
+  Stream<CurriculumLanguage> get stream => _controller.stream;
+
+  String get baseUrl {
+    final domain = AuthenticationService.baseURL;
+    if (_current.slug == 'english') {
+      return '$domain/curriculum-data/v2';
+    }
+    return '$domain/${_current.slug}/curriculum-data/v2';
+  }
+
+  Future<void> init() async {
+    final prefs = await SharedPreferences.getInstance();
+    final slug = prefs.getString(_prefKey) ?? 'english';
+    _current = languages.firstWhere(
+      (l) => l.slug == slug,
+      orElse: () => languages[0],
+    );
+  }
+
+  Future<void> setLanguage(String slug) async {
+    _current = languages.firstWhere(
+      (l) => l.slug == slug,
+      orElse: () => languages[0],
+    );
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_prefKey, _current.slug);
+    _controller.sink.add(_current);
+  }
+}

--- a/mobile-app/lib/ui/views/learn/challenge/templates/template_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/templates/template_viewmodel.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:freecodecamp/app/app.locator.dart';
 import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/service/learn/daily_challenge_service.dart';
 import 'package:freecodecamp/service/learn/learn_offline_service.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
@@ -16,6 +19,12 @@ class ChallengeTemplateViewModel extends BaseViewModel {
   final DailyChallengeService _dailyChallengeService =
       locator<DailyChallengeService>();
   final LearnService _learnService = locator<LearnService>();
+  final CurriculumLanguageService _curriculumLanguageService =
+      locator<CurriculumLanguageService>();
+
+  StreamSubscription<CurriculumLanguage>? _languageSubscription;
+  Block? _block;
+  String? _challengeId;
 
   set setChallenge(Future<Challenge> challenge) {
     _challenge = challenge;
@@ -23,20 +32,33 @@ class ChallengeTemplateViewModel extends BaseViewModel {
   }
 
   void initiate(Block block, String challengeId, DateTime? challengeDate) {
-    if (challengeDate == null) {
-      final String base = LearnService.baseUrl;
-
-      String url =
-          '$base/challenges/${block.superBlock.dashedName}/${block.dashedName}/$challengeId.json';
-
-      setChallenge = _learnOfflineService.getChallenge(url);
-
-      _learnService.setLastVisitedChallenge(url, block);
-    } else {
+    if (challengeDate != null) {
       final formattedChallengeDate = formatChallengeDate(challengeDate);
-
       setChallenge = _dailyChallengeService.getDailyChallenge(
           formattedChallengeDate, block);
+      return;
     }
+
+    _block = block;
+    _challengeId = challengeId;
+
+    _languageSubscription ??=
+        _curriculumLanguageService.stream.listen((_) => _reload());
+
+    _reload();
+  }
+
+  void _reload() {
+    final String url =
+        '${_curriculumLanguageService.baseUrl}/challenges/${_block!.superBlock.dashedName}/${_block!.dashedName}/$_challengeId.json';
+
+    setChallenge = _learnOfflineService.getChallenge(url);
+    _learnService.setLastVisitedChallenge(url, _block!);
+  }
+
+  @override
+  void dispose() {
+    _languageSubscription?.cancel();
+    super.dispose();
   }
 }

--- a/mobile-app/lib/ui/views/learn/chapter/chapter_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/chapter/chapter_viewmodel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -9,7 +11,7 @@ import 'package:freecodecamp/models/main/user_model.dart';
 import 'package:freecodecamp/service/authentication/authentication_service.dart';
 import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/service/firebase/remote_config_service.dart';
-import 'package:freecodecamp/service/learn/learn_service.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
@@ -20,6 +22,12 @@ class ChapterViewModel extends BaseViewModel {
   final AuthenticationService auth = locator<AuthenticationService>();
   final RemoteConfigService _remoteConfigService =
       locator<RemoteConfigService>();
+  final CurriculumLanguageService _curriculumLanguageService =
+      locator<CurriculumLanguageService>();
+
+  StreamSubscription<CurriculumLanguage>? _languageSubscription;
+  String? _superBlockDashedName;
+  String? _superBlockName;
 
   bool _isDev = false;
   bool get isDev => _isDev;
@@ -32,8 +40,28 @@ class ChapterViewModel extends BaseViewModel {
   }
 
   void init(String superBlockDashedName, superBlockName) async {
+    _superBlockDashedName = superBlockDashedName;
+    _superBlockName = superBlockName;
+
+    _languageSubscription ??=
+        _curriculumLanguageService.stream.listen((_) => _reload());
+
     superBlockFuture = requestChapters(superBlockDashedName, superBlockName);
     developmentMode();
+  }
+
+  void _reload() {
+    if (_superBlockDashedName != null && _superBlockName != null) {
+      superBlockFuture =
+          requestChapters(_superBlockDashedName!, _superBlockName!);
+      notifyListeners();
+    }
+  }
+
+  @override
+  void dispose() {
+    _languageSubscription?.cancel();
+    super.dispose();
   }
 
   Future<String> calculateProgress(Module module) async {
@@ -70,7 +98,7 @@ class ChapterViewModel extends BaseViewModel {
 
   Future<SuperBlock?> requestChapters(
       String superBlockDashedName, String superBlockName) async {
-    String baseUrl = LearnService.baseUrl;
+    String baseUrl = _curriculumLanguageService.baseUrl;
 
     final Response res = await _dio.get(
       '$baseUrl/$superBlockDashedName.json',

--- a/mobile-app/lib/ui/views/learn/landing/landing_view.dart
+++ b/mobile-app/lib/ui/views/learn/landing/landing_view.dart
@@ -22,6 +22,28 @@ class LearnLandingView extends StatelessWidget {
         backgroundColor: FccColors.gray90,
         appBar: AppBar(
           title: Text('LEARN'),
+          actions: [
+            PopupMenuButton<String>(
+              color: FccColors.gray85,
+              onSelected: (code) => model.changeLocale(code),
+              itemBuilder: (context) => [
+                for (int i = 0; i < model.curriculumLocaleCodes.length; i++)
+                  PopupMenuItem<String>(
+                    value: model.curriculumLocaleCodes[i],
+                    child: Text(
+                      model.curriculumLocaleNames[i],
+                      style: TextStyle(
+                        color: model.currentLocaleCode ==
+                                model.curriculumLocaleCodes[i]
+                            ? FccColors.blue50
+                            : Colors.white,
+                      ),
+                    ),
+                  ),
+              ],
+              icon: const Icon(Icons.language),
+            ),
+          ],
         ),
         drawer: const DrawerWidgetView(
           key: Key('drawer'),
@@ -256,70 +278,70 @@ class SuperBlockButton extends StatelessWidget {
           vertical: 6,
           horizontal: 4,
         ),
-      constraints: BoxConstraints(
-        minHeight: 80,
-      ),
-      child: ElevatedButton(
-        style: ElevatedButton.styleFrom(
-          padding: const EdgeInsets.all(5),
-          backgroundColor: FccColors.gray80,
-          side: const BorderSide(
-            width: 2,
-            color: FccColors.gray75,
-          ),
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.all(Radius.circular(5)),
+        constraints: BoxConstraints(
+          minHeight: 80,
+        ),
+        child: ElevatedButton(
+          style: ElevatedButton.styleFrom(
+            padding: const EdgeInsets.all(5),
+            backgroundColor: FccColors.gray80,
             side: const BorderSide(
-              color: Colors.teal,
-              width: 2.0,
+              width: 2,
+              color: FccColors.gray75,
+            ),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.all(Radius.circular(5)),
+              side: const BorderSide(
+                color: Colors.teal,
+                width: 2.0,
+              ),
             ),
           ),
-        ),
-        onPressed: () {
-          button.public
-              ? model.routeToSuperBlock(button.path, button.name)
-              : model.disabledButtonSnack(button.disabledByManualOverride);
-        },
-        child: Row(
-          children: [
-            Padding(
-              padding: const EdgeInsets.all(12.0),
-              child: SizedBox(
-                width: 36,
-                height: 36,
-                child: SvgPicture.asset(
-                  iconMap[SuperBlocks.fromValue(button.path)] ??
-                      '${SuperBlockButton.learnAssetsPath}/graduation.svg',
-                  fit: BoxFit.contain,
-                  colorFilter: ColorFilter.mode(
-                    FccColors.gray00,
-                    BlendMode.srcIn,
+          onPressed: () {
+            button.public
+                ? model.routeToSuperBlock(button.path, button.name)
+                : model.disabledButtonSnack(button.disabledByManualOverride);
+          },
+          child: Row(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(12.0),
+                child: SizedBox(
+                  width: 36,
+                  height: 36,
+                  child: SvgPicture.asset(
+                    iconMap[SuperBlocks.fromValue(button.path)] ??
+                        '${SuperBlockButton.learnAssetsPath}/graduation.svg',
+                    fit: BoxFit.contain,
+                    colorFilter: ColorFilter.mode(
+                      FccColors.gray00,
+                      BlendMode.srcIn,
+                    ),
                   ),
                 ),
               ),
-            ),
-            Expanded(
-              flex: 8,
-              child: Text(
-                button.name,
-                textAlign: TextAlign.left,
-                style: const TextStyle(fontSize: 20),
-              ),
-            ),
-            const Expanded(
-              flex: 2,
-              child: Align(
-                alignment: Alignment.centerRight,
-                child: Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                  child: Icon(Icons.arrow_forward_ios),
+              Expanded(
+                flex: 8,
+                child: Text(
+                  button.name,
+                  textAlign: TextAlign.left,
+                  style: const TextStyle(fontSize: 20),
                 ),
               ),
-            )
-          ],
+              const Expanded(
+                flex: 2,
+                child: Align(
+                  alignment: Alignment.centerRight,
+                  child: Padding(
+                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
+                    child: Icon(Icons.arrow_forward_ios),
+                  ),
+                ),
+              )
+            ],
+          ),
         ),
       ),
-    ),
     );
   }
 }

--- a/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
@@ -17,6 +17,7 @@ import 'package:freecodecamp/models/main/user_model.dart';
 import 'package:freecodecamp/service/authentication/authentication_service.dart';
 import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/service/firebase/remote_config_service.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/service/learn/daily_challenge_service.dart';
 import 'package:freecodecamp/service/learn/learn_offline_service.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
@@ -41,6 +42,19 @@ class LearnLandingViewModel extends BaseViewModel {
 
   final _learnOfflineService = locator<LearnOfflineService>();
   LearnOfflineService get learnOfflineService => _learnOfflineService;
+
+  final CurriculumLanguageService _curriculumLanguageService =
+      locator<CurriculumLanguageService>();
+  StreamSubscription<CurriculumLanguage>? _languageSubscription;
+
+  String get currentLocaleCode => _curriculumLanguageService.current.slug;
+  List<String> get curriculumLocaleCodes =>
+      CurriculumLanguageService.languages.map((l) => l.slug).toList();
+  List<String> get curriculumLocaleNames =>
+      CurriculumLanguageService.languages.map((l) => l.name).toList();
+
+  void changeLocale(String slug) =>
+      _curriculumLanguageService.setLanguage(slug);
 
   final _dailyChallengeService = DailyChallengeService();
   final _remoteConfigService = locator<RemoteConfigService>();
@@ -78,8 +92,16 @@ class LearnLandingViewModel extends BaseViewModel {
     setupDialogUi();
     retrieveNewQuote();
     initLoggedInListener();
+    _languageSubscription =
+        _curriculumLanguageService.stream.listen((_) => _loadInitialData());
 
     _loadInitialData();
+  }
+
+  @override
+  void dispose() {
+    _languageSubscription?.cancel();
+    super.dispose();
   }
 
   Future<void> _loadInitialData() async {
@@ -119,7 +141,7 @@ class LearnLandingViewModel extends BaseViewModel {
         lastVisitedChallenge[0],
       );
 
-      String baseUrl = LearnService.baseUrl;
+      String baseUrl = _curriculumLanguageService.baseUrl;
 
       final Response res =
           await _dio.get('$baseUrl/${lastVisitedChallenge[1]}.json');
@@ -184,7 +206,7 @@ class LearnLandingViewModel extends BaseViewModel {
   }
 
   Future<List<Widget>> requestSuperBlocks() async {
-    String baseUrl = LearnService.baseUrl;
+    String baseUrl = _curriculumLanguageService.baseUrl;
 
     TextStyle headerStyle = TextStyle(fontSize: 21);
 

--- a/mobile-app/lib/ui/views/learn/superblock/superblock_view.dart
+++ b/mobile-app/lib/ui/views/learn/superblock/superblock_view.dart
@@ -28,7 +28,7 @@ class SuperBlockView extends StatelessWidget {
           model.auth.fetchUser();
         }
 
-        model.setSuperBlockData = model.getSuperBlockData(
+        model.init(
           superBlockDashedName,
           superBlockName,
           hasInternet,

--- a/mobile-app/lib/ui/views/learn/superblock/superblock_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/superblock/superblock_viewmodel.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:freecodecamp/app/app.locator.dart';
@@ -5,11 +7,13 @@ import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/service/authentication/authentication_service.dart';
 import 'package:freecodecamp/service/dio_service.dart';
 import 'package:freecodecamp/service/firebase/remote_config_service.dart';
+import 'package:freecodecamp/service/learn/curriculum_language_service.dart';
 import 'package:freecodecamp/service/learn/learn_offline_service.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
 import 'package:stacked/stacked.dart';
 
 class SuperBlockViewModel extends BaseViewModel {
+  final _curriculumLanguageService = locator<CurriculumLanguageService>();
   final _learnOfflineService = locator<LearnOfflineService>();
   LearnOfflineService get learnOfflineService => _learnOfflineService;
 
@@ -22,6 +26,11 @@ class SuperBlockViewModel extends BaseViewModel {
 
   final _dio = DioService.dio;
 
+  StreamSubscription<CurriculumLanguage>? _languageSubscription;
+  String? _dashedName;
+  String? _name;
+  bool _hasInternet = true;
+
   Map<String, bool> _blockOpenStates = {};
   Map<String, bool> get blockOpenStates => _blockOpenStates;
 
@@ -31,6 +40,29 @@ class SuperBlockViewModel extends BaseViewModel {
   set setSuperBlockData(Future<SuperBlock>? superBlockData) {
     _superBlockData = superBlockData;
     notifyListeners();
+  }
+
+  void init(String dashedName, String name, bool hasInternet) {
+    _dashedName = dashedName;
+    _name = name;
+    _hasInternet = hasInternet;
+
+    _languageSubscription ??=
+        _curriculumLanguageService.stream.listen((_) => _reload());
+
+    setSuperBlockData = getSuperBlockData(dashedName, name, hasInternet);
+  }
+
+  void _reload() {
+    if (_dashedName != null && _name != null) {
+      setSuperBlockData = getSuperBlockData(_dashedName!, _name!, _hasInternet);
+    }
+  }
+
+  @override
+  void dispose() {
+    _languageSubscription?.cancel();
+    super.dispose();
   }
 
   set blockOpenStates(Map<String, bool> openStates) {
@@ -64,7 +96,7 @@ class SuperBlockViewModel extends BaseViewModel {
     String name,
     bool hasInternet,
   ) async {
-    String baseUrl = LearnService.baseUrl;
+    String baseUrl = _curriculumLanguageService.baseUrl;
 
     if (!hasInternet) {
       final cachedBlocks =


### PR DESCRIPTION
## Summary

- Add a persisted curriculum language service and register it with the app locator.
- Add a language selector to the Learn screen app bar.
- Reload learn landing, superblock, chapter, and challenge data when the selected curriculum language changes.

## Validation

- dart format on touched Dart files
- git diff --check
- flutter analyze
