### PR TITLE
Add copy action to code blocks

### DIFF
--- a/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
+++ b/mobile-app/lib/ui/views/news/html_handler/html_handler.dart
@@ -110,6 +110,23 @@ class HTMLParser {
 
   final BuildContext context;
 
+  void _copyToClipboard(String text, String copiedMessage) {
+    Clipboard.setData(ClipboardData(text: text));
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        backgroundColor: FccColors.gray75,
+        content: Text(
+          copiedMessage,
+          style: const TextStyle(
+            color: FccSemanticColors.foregroundPrimary,
+            fontSize: 20,
+          ),
+        ),
+        duration: const Duration(seconds: 1),
+      ),
+    );
+  }
+
   List<Widget> parse(
     String html, {
     bool isSelectable = true,
@@ -201,19 +218,59 @@ class HTMLParser {
             }
 
             List classes = codeElement.classes.toList();
+            String codeText = codeElement.text.trimRight();
 
-            return Editor(
-              options: EditorOptions(
-                fontFamily: 'Hack',
-                takeFullHeight: false,
-                isEditable: false,
-                showLinebar: false,
+            return Container(
+              color: FccColors.gray80,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Editor(
+                      options: EditorOptions(
+                        fontFamily: 'Hack',
+                        takeFullHeight: false,
+                        isEditable: false,
+                        showLinebar: false,
+                      ),
+                      defaultLanguage: codeLanguageIsPresent(classes)
+                          ? currentClass!.split('-')[1]
+                          : '',
+                      defaultValue: codeText,
+                      path: 'example',
+                    ),
+                  ),
+                  SelectionContainer.disabled(
+                    child: Padding(
+                      padding: const EdgeInsets.only(top: 4, right: 12),
+                      child: Tooltip(
+                        message: 'Copy code',
+                        child: Semantics(
+                          label: 'Copy code block',
+                          button: true,
+                          child: GestureDetector(
+                            behavior: HitTestBehavior.opaque,
+                            onTap: () {
+                              _copyToClipboard(
+                                codeText,
+                                'Code copied to clipboard!',
+                              );
+                            },
+                            child: const SizedBox.square(
+                              dimension: 28,
+                              child: Icon(
+                                Icons.copy,
+                                size: 20,
+                                color: FccSemanticColors.foregroundPrimary,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
               ),
-              defaultLanguage: codeLanguageIsPresent(classes)
-                  ? currentClass!.split('-')[1]
-                  : '',
-              defaultValue: codeElement.text.trimRight(),
-              path: 'example',
             );
           },
         ),
@@ -253,29 +310,7 @@ class HTMLParser {
 
             return InkWell(
               onTap: () {
-                Clipboard.setData(ClipboardData(text: parsed));
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text.rich(
-                      TextSpan(
-                        children: [
-                          TextSpan(
-                            text: parsed,
-                            style: const TextStyle(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 20,
-                            ),
-                          ),
-                          const TextSpan(
-                            text: ' copied to clipboard!',
-                            style: TextStyle(fontSize: 20),
-                          ),
-                        ],
-                      ),
-                    ),
-                    duration: const Duration(seconds: 1),
-                  ),
-                );
+                _copyToClipboard(parsed, '$parsed copied to clipboard!');
               },
               child: Text(
                 parsed,

--- a/mobile-app/test/widget/html_handler_test.dart
+++ b/mobile-app/test/widget/html_handler_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  String? clipboardText;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    clipboardText = null;
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, (call) async {
+      switch (call.method) {
+        case 'Clipboard.setData':
+          clipboardText = call.arguments['text'] as String?;
+          return null;
+        case 'Clipboard.getData':
+          return {'text': clipboardText};
+      }
+
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(SystemChannels.platform, null);
+  });
+
+  Widget htmlParserFixture(String html) {
+    return MaterialApp(
+      home: Scaffold(
+        body: Builder(
+          builder: (context) {
+            final parser = HTMLParser(context: context);
+
+            return Column(
+              children: parser.parse(html),
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  testWidgets('copies the contents of a pre code block', (tester) async {
+    const code = '<p>Hello</p>\nconst answer = 42;';
+
+    await tester.pumpWidget(
+      htmlParserFixture(
+        '<pre><code class="language-html">&lt;p&gt;Hello&lt;/p&gt;\nconst answer = 42;</code></pre>',
+      ),
+    );
+    await tester.pump();
+
+    expect(find.byTooltip('Copy code'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.copy));
+    await tester.pump();
+
+    expect(clipboardText, code);
+    expect(find.text('Code copied to clipboard!'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add a copy control to rendered block code examples
- reuse the clipboard/snackbar behavior for inline code and block code
- add a widget test that verifies block code content is copied

## Why
Read-only code examples were rendered through an embedded editor without a reliable way to copy the full snippet, especially when content overflowed horizontally.

## Impact
Learners can copy code examples directly from lessons and other HTML-rendered content.

## Validation
- dart analyze lib/ui/views/news/html_handler/html_handler.dart test/widget/html_handler_test.dart
- flutter test test/widget/html_handler_test.dart