### PR TITLE
feat(learn): add web-only indicator icon and direct browser launch fo…

### DIFF
--- a/mobile-app/lib/ui/views/learn/landing/landing_view.dart
+++ b/mobile-app/lib/ui/views/learn/landing/landing_view.dart
@@ -8,6 +8,7 @@ import 'package:freecodecamp/models/learn/motivational_quote_model.dart';
 import 'package:freecodecamp/models/main/user_model.dart';
 import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:freecodecamp/ui/views/learn/landing/landing_viewmodel.dart';
+import 'package:freecodecamp/ui/views/learn/utils/learn_globals.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/daily_challenge_card.dart';
 import 'package:freecodecamp/ui/widgets/drawer_widget/drawer_widget_view.dart';
 import 'package:stacked/stacked.dart';
@@ -252,14 +253,16 @@ class SuperBlockButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isWebOnly = webOnlySuperBlocks.contains(button.path);
+
     return Opacity(
-      opacity: button.public ? 1.0 : 0.7,
+      opacity: (button.public || isWebOnly) ? 1.0 : 0.7,
       child: Container(
         padding: const EdgeInsets.symmetric(
           vertical: 6,
           horizontal: 4,
         ),
-        constraints: BoxConstraints(
+        constraints: const BoxConstraints(
           minHeight: 80,
         ),
         child: ElevatedButton(
@@ -270,18 +273,22 @@ class SuperBlockButton extends StatelessWidget {
               width: 2,
               color: FccColors.gray75,
             ),
-            shape: RoundedRectangleBorder(
+            shape: const RoundedRectangleBorder(
               borderRadius: BorderRadius.all(Radius.circular(5)),
-              side: const BorderSide(
+              side: BorderSide(
                 color: Colors.teal,
                 width: 2.0,
               ),
             ),
           ),
           onPressed: () {
-            button.public
-                ? model.routeToSuperBlock(button.path, button.name)
-                : model.disabledButtonSnack(button.disabledByManualOverride);
+            if (isWebOnly) {
+              model.openInBrowser(button.path);
+            } else if (button.public) {
+              model.routeToSuperBlock(button.path, button.name);
+            } else {
+              model.disabledButtonSnack(button.disabledByManualOverride);
+            }
           },
           child: Row(
             children: [
@@ -294,7 +301,7 @@ class SuperBlockButton extends StatelessWidget {
                     iconMap[SuperBlocks.fromValue(button.path)] ??
                         '${SuperBlockButton.learnAssetsPath}/graduation.svg',
                     fit: BoxFit.contain,
-                    colorFilter: ColorFilter.mode(
+                    colorFilter: const ColorFilter.mode(
                       FccColors.gray00,
                       BlendMode.srcIn,
                     ),
@@ -309,13 +316,23 @@ class SuperBlockButton extends StatelessWidget {
                   style: const TextStyle(fontSize: 20),
                 ),
               ),
-              const Expanded(
+              Expanded(
                 flex: 2,
                 child: Align(
                   alignment: Alignment.centerRight,
                   child: Padding(
-                    padding: EdgeInsets.symmetric(vertical: 8, horizontal: 12),
-                    child: Icon(Icons.arrow_forward_ios),
+                    padding: const EdgeInsets.symmetric(
+                      vertical: 8,
+                      horizontal: 12,
+                    ),
+                    child: Tooltip(
+                      message: isWebOnly ? context.t.not_available_web : '',
+                      child: Icon(
+                        isWebOnly
+                            ? Icons.open_in_new
+                            : Icons.arrow_forward_ios,
+                      ),
+                    ),
                   ),
                 ),
               )

--- a/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
+++ b/mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart
@@ -28,6 +28,7 @@ import 'package:freecodecamp/ui/widgets/setup_dialog_ui.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:stacked/stacked.dart';
 import 'package:stacked_services/stacked_services.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 class LearnLandingViewModel extends BaseViewModel {
   final NavigationService _navigationService = locator<NavigationService>();
@@ -186,6 +187,12 @@ class LearnLandingViewModel extends BaseViewModel {
     Future.delayed(const Duration(milliseconds: 2500), () {
       snack.closeSnackbar();
     });
+  }
+
+  void openInBrowser(String dashedName) {
+    launchUrl(
+      Uri.parse('${AuthenticationService.baseURL}/learn/$dashedName'),
+    );
   }
 
   Future<List<Widget>> requestSuperBlocks() async {

--- a/mobile-app/lib/ui/views/learn/utils/learn_globals.dart
+++ b/mobile-app/lib/ui/views/learn/utils/learn_globals.dart
@@ -15,3 +15,13 @@ const chapterBasedSuperBlocks = [
   'a1-professional-spanish',
   'python-v9'
 ];
+
+/// SuperBlocks that require a web browser and cannot be completed
+/// in the mobile app. Tapping these opens freecodecamp.org in the browser.
+const webOnlySuperBlocks = [
+  'coding-interview-prep',
+  'project-euler',
+  'rosetta-code',
+  'the-odin-project',
+  'foundational-c-sharp-with-microsoft',
+];


### PR DESCRIPTION
## Description
Adds a visual indicator (`open_in_new` icon) to course cards on the Learn page for superblocks that require a web browser (Coding Interview Prep, Project Euler, Rosetta Code, The Odin Project, Foundational C# with Microsoft). Tapping these cards now routes the user directly to the course in the web browser instead of showing a snackbar message or opening incomplete in-app templates.

## Motivation & Context
Previously, web-only courses looked identical to mobile-native courses with an arrow (`>`) icon. Users only discovered that a course required a web browser after tapping it, resulting in an inconsistent user experience.

## Changes Made
- **`mobile-app/lib/ui/views/learn/utils/learn_globals.dart`**: Added `webOnlySuperBlocks` registry listing dashed names of browser-required courses (following existing `hasNoCert`, `hasDialogue`, and `chapterBasedSuperBlocks` patterns).
- **`mobile-app/lib/ui/views/learn/landing/landing_viewmodel.dart`**: Added `openInBrowser(String dashedName)` to launch `${AuthenticationService.baseURL}/learn/$dashedName` using `url_launcher`.
- **`mobile-app/lib/ui/views/learn/landing/landing_view.dart`**:
  - Displays `Icons.open_in_new` trailing icon for web-only courses.
  - Adds `Tooltip` showing `"Not available use the web version"` (`context.t.not_available_web`) on long press.
  - Directly launches browser on tap when `isWebOnly` is true.

## Checklist
- [x] Tested and verified no regressions on mobile-native courses.
- [x] Follows existing project architecture and naming conventions.
- [x] Reuses existing localization keys (`not_available_web`).
- [x] Clean minimal changes (~35 lines across 3 files).
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/ccd2af66-3b97-4968-a41d-3a8b418ab5e4" />