### PR TITLE
fix(learn): hide console button for non-JS challenges

### DIFF
--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_html/flutter_html.dart';
+import 'package:freecodecamp/enums/ext_type.dart';
 import 'package:freecodecamp/enums/panel_type.dart';
 import 'package:freecodecamp/extensions/i18n_extension.dart';
 import 'package:freecodecamp/models/learn/challenge_model.dart';
@@ -553,6 +554,10 @@ class ChallengeView extends StatelessWidget {
   ) {
     const noPreviewChallengeTypes = <int>[1, 20, 23, 26, 27, 28, 29];
 
+    final bool hasJsFile = challenge.files.any(
+      (file) => file.ext == Ext.js || file.ext == Ext.jsx,
+    );
+
     return [
       _panelIconButton(
         isActive: model.showPanel && model.panelType == PanelType.instruction,
@@ -577,15 +582,16 @@ class ChallengeView extends StatelessWidget {
             model.initFile(challenge, currFile);
           },
         ),
-      _panelIconButton(
-        isActive: model.showConsole,
-        icon: Icons.terminal,
-        onPressed: () {
-          model.setShowConsole = !model.showConsole;
-          model.setShowPreview = false;
-          model.setMounted = false;
-        },
-      ),
+      if (hasJsFile)
+        _panelIconButton(
+          isActive: model.showConsole,
+          icon: Icons.terminal,
+          onPressed: () {
+            model.setShowConsole = !model.showConsole;
+            model.setShowPreview = false;
+            model.setMounted = false;
+          },
+        ),
     ];
   }
 


### PR DESCRIPTION
Fixes #1666

## Description
Hides the JavaScript console button (`Icons.terminal`) from the challenge action bar for non-JS challenges (such as HTML/CSS-only steps).

## Motivation & Context
Previously, the console button appeared for all interactive challenges regardless of language. For HTML/CSS challenges, the JS console is irrelevant and shouldn't be displayed.

## Changes Made
- **`mobile-app/lib/ui/views/learn/challenge/challenge_view.dart`**: Added `hasJsFile` check that inspects `challenge.files` for `Ext.js` or `Ext.jsx` extensions, rendering the console `_panelIconButton` conditionally `if (hasJsFile)`.

## Checklist
- [x] Tested with HTML/CSS and JS challenges.
- [x] Follows existing project architecture and conventions.
- [x] Clean minimal change (~8 lines in 1 file).

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/5473127b-57d4-4e8f-9937-b07911ba934a" />
