### PR TITLE
fix(learn): fix workshop progress bar calculation and deduplicate cha…

### DIFF
--- a/mobile-app/lib/models/learn/curriculum_model.dart
+++ b/mobile-app/lib/models/learn/curriculum_model.dart
@@ -242,27 +242,41 @@ class Block {
       dashedName: dashedName,
       description: finalDescription,
       order: data['order'],
-      challenges: (data['challengeOrder'] as List)
-          .map<ChallengeOrder>(
-            (dynamic challenge) => ChallengeOrder(
-              id: challenge[0] ?? challenge['id'],
-              title: challenge[1] ?? challenge['title'],
-            ),
-          )
-          .toList(),
-      challengeTiles: (data['challengeOrder'] as List)
-          .map<ChallengeListTile>(
-            (dynamic challenge) => ChallengeListTile(
-              id: challenge[0] ?? challenge['id'],
-              name: challenge[1] ?? challenge['title'],
-              dashedName: challenge[1] ??
-                  challenge['title']
-                      .toLowerCase()
-                      .replaceAll(' ', '-')
-                      .replaceAll(RegExp(r"[@':]"), ''),
-            ),
-          )
-          .toList(),
+      challenges: () {
+        final Set<String> seenIds = {};
+        final List<ChallengeOrder> list = [];
+        for (dynamic challenge in (data['challengeOrder'] as List? ?? [])) {
+          final String id = challenge[0] ?? challenge['id'];
+          final String title = challenge[1] ?? challenge['title'];
+          if (!seenIds.contains(id)) {
+            seenIds.add(id);
+            list.add(ChallengeOrder(id: id, title: title));
+          }
+        }
+        return list;
+      }(),
+      challengeTiles: () {
+        final Set<String> seenIds = {};
+        final List<ChallengeListTile> list = [];
+        for (dynamic challenge in (data['challengeOrder'] as List? ?? [])) {
+          final String id = challenge[0] ?? challenge['id'];
+          final String title = challenge[1] ?? challenge['title'];
+          if (!seenIds.contains(id)) {
+            seenIds.add(id);
+            list.add(
+              ChallengeListTile(
+                id: id,
+                name: title,
+                dashedName: title
+                    .toLowerCase()
+                    .replaceAll(' ', '-')
+                    .replaceAll(RegExp(r"[@':]"), ''),
+              ),
+            );
+          }
+        }
+        return list;
+      }(),
     );
   }
 }

--- a/mobile-app/lib/ui/views/learn/widgets/pass/pass_widget_view.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/pass/pass_widget_view.dart
@@ -91,7 +91,10 @@ class PassWidgetView extends StatelessWidget {
                                       Padding(
                                         padding: const EdgeInsets.all(16.0),
                                         child: LinearProgressIndicator(
-                                          value: completed / maxChallenges,
+                                          value: maxChallenges > 0
+                                              ? (completed / maxChallenges)
+                                                  .clamp(0.0, 1.0)
+                                              : 0.0,
                                           minHeight: 7,
                                           backgroundColor: const Color.fromRGBO(
                                               0x3B, 0x3B, 0x4F, 1),
@@ -106,10 +109,13 @@ class PassWidgetView extends StatelessWidget {
                                             Expanded(
                                               child: Text(
                                                 context.t.completed_percent(
-                                                  ((completed * 100) /
-                                                          maxChallenges)
-                                                      .round()
-                                                      .toString(),
+                                                  maxChallenges > 0
+                                                      ? (((completed * 100) /
+                                                              maxChallenges)
+                                                          .clamp(0, 100)
+                                                          .round()
+                                                          .toString())
+                                                      : '0',
                                                 ),
                                                 textAlign: TextAlign.right,
                                               ),


### PR DESCRIPTION
Fixes #1785

## Description
Fixes an issue where workshops and labs (e.g. in JS and Python certs) display incorrect progress (adding 10% per step instead of 20%) and only reach 50% completion when all steps are finished.

## Motivation & Context
`Block.fromJson` parsed `data['challengeOrder']` without deduplicating challenge IDs. When duplicate challenge entries existed in block metadata, `block.challenges.length` became double the actual step count (e.g. 10 instead of 5), while user progress only records 1 completion per unique challenge ID (e.g. 5). Thus `5 / 10 = 50%`.

## Changes Made
- **`mobile-app/lib/models/learn/curriculum_model.dart`**: Deduplicated `challengeOrder` by `id` in `Block.fromJson` to ensure `challenges` and `challengeTiles` contain accurate unique step counts.
- **`mobile-app/lib/ui/views/learn/widgets/pass/pass_widget_view.dart`**: Added `.clamp(0.0, 1.0)` and `.clamp(0, 100)` bounds safety to progress indicators.

## Checklist
- [x] Verified progress calculation logic.
- [x] Follows existing project architecture and conventions.
- [x] Clean minimal changes across 2 files.
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/be881646-c5a9-48f1-888e-c3ae02b3d50d" />

