### PR TITLE
fix: correct not available on web tooltip

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -671,7 +671,7 @@
     "@temporarily_unavailable": {
         "description": "snackbar shown when a curriculum item is temporarily disabled"
     },
-    "not_available_web": "Not available use the web version",
+    "not_available_web": "Not available - use the web version",
     "@not_available_web": {
         "description": "snackbar shown when a curriculum item is only available on the web"
     },

--- a/mobile-app/lib/l10n/app_es.arb
+++ b/mobile-app/lib/l10n/app_es.arb
@@ -613,7 +613,7 @@
   "no_blocks_available": "No blocks available right now.",
   "coming_soon": "Coming Soon",
   "temporarily_unavailable": "Temporarily unavailable, come back soon.",
-  "not_available_web": "Not available use the web version",
+  "not_available_web": "Not available - use the web version",
   "stage_core": "Recommended curriculum (still in beta):",
   "stage_english": "Learn English for Developers:",
   "stage_spanish": "Learn Professional Spanish:",

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -1070,7 +1070,7 @@ abstract class AppLocalizations {
   /// snackbar shown when a curriculum item is only available on the web
   ///
   /// In en, this message translates to:
-  /// **'Not available use the web version'**
+  /// **'Not available - use the web version'**
   String get not_available_web;
 
   /// learn landing heading for recommended curriculum stage

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -577,7 +577,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
-  String get not_available_web => 'Not available use the web version';
+  String get not_available_web => 'Not available - use the web version';
 
   @override
   String get stage_core => 'Recommended curriculum (still in beta):';

--- a/mobile-app/lib/l10n/app_localizations_es.dart
+++ b/mobile-app/lib/l10n/app_localizations_es.dart
@@ -577,7 +577,7 @@ class AppLocalizationsEs extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
-  String get not_available_web => 'Not available use the web version';
+  String get not_available_web => 'Not available - use the web version';
 
   @override
   String get stage_core => 'Recommended curriculum (still in beta):';

--- a/mobile-app/lib/l10n/app_localizations_pt.dart
+++ b/mobile-app/lib/l10n/app_localizations_pt.dart
@@ -577,7 +577,7 @@ class AppLocalizationsPt extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
-  String get not_available_web => 'Not available use the web version';
+  String get not_available_web => 'Not available - use the web version';
 
   @override
   String get stage_core => 'Recommended curriculum (still in beta):';

--- a/mobile-app/lib/l10n/app_pt.arb
+++ b/mobile-app/lib/l10n/app_pt.arb
@@ -613,7 +613,7 @@
   "no_blocks_available": "No blocks available right now.",
   "coming_soon": "Coming Soon",
   "temporarily_unavailable": "Temporarily unavailable, come back soon.",
-  "not_available_web": "Not available use the web version",
+  "not_available_web": "Not available - use the web version",
   "stage_core": "Recommended curriculum (still in beta):",
   "stage_english": "Learn English for Developers:",
   "stage_spanish": "Learn Professional Spanish:",


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

Closes #1827

The `not_available_web` snackbar was missing a separator and read `Not available use the web version`. This updates it to `Not available - use the web version`, matching the wording of the neighbouring `coming_soon_web` string (`Coming soon - use the web version`).

The string is shown by `disabledButtonSnack()` in `lib/ui/views/learn/landing/landing_viewmodel.dart` when a curriculum item is web-only.

The same correction is applied to `app_es.arb` and `app_pt.arb`, which both carry the untranslated English string, along with the corresponding generated localization files.

Verified locally on Flutter 3.44.9 (the version pinned in CI):
- `flutter pub get` regenerates the localization files with no further diff, so the committed generated output matches `gen-l10n` exactly
- `flutter analyze --no-fatal-warnings` reports no new issues
- `flutter test unit` and `flutter test services` pass
