### PR TITLE
feat: add share button for challenge links

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -671,6 +671,10 @@
     "@temporarily_unavailable": {
         "description": "snackbar shown when a curriculum item is temporarily disabled"
     },
+    "share_challenge": "Share this challenge",
+    "@share_challenge": {
+        "description": "tooltip for the button that shares a link to the current challenge"
+    },
     "not_available_web": "Not available use the web version",
     "@not_available_web": {
         "description": "snackbar shown when a curriculum item is only available on the web"

--- a/mobile-app/lib/l10n/app_es.arb
+++ b/mobile-app/lib/l10n/app_es.arb
@@ -613,6 +613,7 @@
   "no_blocks_available": "No blocks available right now.",
   "coming_soon": "Coming Soon",
   "temporarily_unavailable": "Temporarily unavailable, come back soon.",
+  "share_challenge": "Share this challenge",
   "not_available_web": "Not available use the web version",
   "stage_core": "Recommended curriculum (still in beta):",
   "stage_english": "Learn English for Developers:",

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -1067,6 +1067,12 @@ abstract class AppLocalizations {
   /// **'Temporarily unavailable, come back soon.'**
   String get temporarily_unavailable;
 
+  /// tooltip for the button that shares a link to the current challenge
+  ///
+  /// In en, this message translates to:
+  /// **'Share this challenge'**
+  String get share_challenge;
+
   /// snackbar shown when a curriculum item is only available on the web
   ///
   /// In en, this message translates to:

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -577,6 +577,9 @@ class AppLocalizationsEn extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
+  String get share_challenge => 'Share this challenge';
+
+  @override
   String get not_available_web => 'Not available use the web version';
 
   @override

--- a/mobile-app/lib/l10n/app_localizations_es.dart
+++ b/mobile-app/lib/l10n/app_localizations_es.dart
@@ -577,6 +577,9 @@ class AppLocalizationsEs extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
+  String get share_challenge => 'Share this challenge';
+
+  @override
   String get not_available_web => 'Not available use the web version';
 
   @override

--- a/mobile-app/lib/l10n/app_localizations_pt.dart
+++ b/mobile-app/lib/l10n/app_localizations_pt.dart
@@ -577,6 +577,9 @@ class AppLocalizationsPt extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
+  String get share_challenge => 'Share this challenge';
+
+  @override
   String get not_available_web => 'Not available use the web version';
 
   @override

--- a/mobile-app/lib/l10n/app_pt.arb
+++ b/mobile-app/lib/l10n/app_pt.arb
@@ -613,6 +613,7 @@
   "no_blocks_available": "No blocks available right now.",
   "coming_soon": "Coming Soon",
   "temporarily_unavailable": "Temporarily unavailable, come back soon.",
+  "share_challenge": "Share this challenge",
   "not_available_web": "Not available use the web version",
   "stage_core": "Recommended curriculum (still in beta):",
   "stage_english": "Learn English for Developers:",

--- a/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
+++ b/mobile-app/lib/ui/views/learn/challenge/challenge_view.dart
@@ -7,10 +7,12 @@ import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/models/learn/daily_challenge_model.dart';
 import 'package:freecodecamp/ui/theme/fcc_theme.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/challenge_viewmodel.dart';
+import 'package:freecodecamp/ui/views/learn/utils/challenge_utils.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/project_preview.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/challenge_widgets/symbol_bar.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/console/console_view.dart';
 import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:stacked/stacked.dart';
 
 class ChallengeView extends StatelessWidget {
@@ -268,6 +270,7 @@ class ChallengeView extends StatelessWidget {
           Row(
             children: [
               ..._panelIconButtons(
+                context,
                 model,
                 challenge,
                 block,
@@ -485,6 +488,7 @@ class ChallengeView extends StatelessWidget {
     required bool isActive,
     required IconData icon,
     required VoidCallback? onPressed,
+    String? tooltip,
   }) {
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 8),
@@ -499,6 +503,7 @@ class ChallengeView extends StatelessWidget {
               : Colors.white,
         ),
         onPressed: onPressed,
+        tooltip: tooltip,
         splashColor: Colors.transparent,
         highlightColor: Colors.transparent,
       ),
@@ -547,6 +552,7 @@ class ChallengeView extends StatelessWidget {
   }
 
   List<Widget> _panelIconButtons(
+    BuildContext context,
     ChallengeViewModel model,
     Challenge challenge,
     Block block,
@@ -584,6 +590,19 @@ class ChallengeView extends StatelessWidget {
           model.setShowConsole = !model.showConsole;
           model.setShowPreview = false;
           model.setMounted = false;
+        },
+      ),
+      _panelIconButton(
+        isActive: false,
+        icon: Icons.share,
+        tooltip: context.t.share_challenge,
+        onPressed: () {
+          SharePlus.instance.share(
+            ShareParams(
+              text:
+                  '${block.name} - ${challenge.title}\n\n${challengeUrl(challenge)}',
+            ),
+          );
         },
       ),
     ];

--- a/mobile-app/lib/ui/views/learn/utils/challenge_utils.dart
+++ b/mobile-app/lib/ui/views/learn/utils/challenge_utils.dart
@@ -1,6 +1,12 @@
 import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 
+// Builds the public freeCodeCamp URL of a challenge, so campers can share the
+// exact step they are on.
+String challengeUrl(Challenge challenge) {
+  return 'https://www.freecodecamp.org/learn/${challenge.superBlock}/${challenge.block}/${challenge.dashedName}';
+}
+
 String handleChallengeTitle(Challenge challenge, Block block) {
   if (block.challenges.length == 1 ||
       challenge.title.contains('Dialogue') ||

--- a/mobile-app/lib/ui/views/learn/widgets/hint/hint_widget_view.dart
+++ b/mobile-app/lib/ui/views/learn/widgets/hint/hint_widget_view.dart
@@ -4,6 +4,7 @@ import 'package:freecodecamp/models/learn/challenge_model.dart';
 import 'package:freecodecamp/models/learn/curriculum_model.dart';
 import 'package:freecodecamp/service/learn/learn_service.dart';
 import 'package:freecodecamp/ui/views/learn/challenge/challenge_viewmodel.dart';
+import 'package:freecodecamp/ui/views/learn/utils/challenge_utils.dart';
 import 'package:freecodecamp/ui/views/learn/widgets/hint/hint_widget_model.dart';
 import 'package:freecodecamp/ui/views/news/html_handler/html_handler.dart';
 import 'package:freecodecamp/utils/helpers.dart';
@@ -26,7 +27,7 @@ Future<String> genForumLink(
   final titleText = '$blockTitle - ${currChallenge.title}';
   final t = context.t;
   final String endingText =
-      '**${t.forum_mobile_info}**\n```txt\n$userDeviceInfo\n```\n\n**${t.forum_challenge}** $titleText\n\n**${t.forum_challenge_link}**\nhttps://www.freecodecamp.org/learn/${currChallenge.superBlock}/${currChallenge.block}/${currChallenge.dashedName}';
+      '**${t.forum_mobile_info}**\n```txt\n$userDeviceInfo\n```\n\n**${t.forum_challenge}** $titleText\n\n**${t.forum_challenge_link}**\n${challengeUrl(currChallenge)}';
 
   final String userCode = await filesToMarkdown(currChallenge, editorText);
 

--- a/mobile-app/test/unit/challenge_utils_test.dart
+++ b/mobile-app/test/unit/challenge_utils_test.dart
@@ -40,6 +40,17 @@ void main() {
     );
   }
 
+  group('challengeUrl', () {
+    test('should build the public learn URL of a challenge', () {
+      final challenge = createChallenge(id: '1', title: 'Step 1');
+
+      expect(
+        challengeUrl(challenge),
+        'https://www.freecodecamp.org/learn/superblock/block1/challenge-1',
+      );
+    });
+  });
+
   group('handleChallengeTitle', () {
     test('should return empty string if the block contains a single challenge',
         () {


### PR DESCRIPTION
Checklist:

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).
- [x] My pull request targets the `main` branch of the repo.
- [x] I have tested these changes locally on my machine.

Closes #1295

Adds a share button to the challenge bottom bar so campers can share a link to the exact step they are on, rather than posting screenshots of the instructions or their code when asking for help on Discord or the forum.

Tapping it opens the native share sheet with, for example:

```
Build a Curriculum Outline - Step 1

https://www.freecodecamp.org/learn/responsive-web-design-v9/workshop-curriculum-outline/step-1
```

The share sheet includes "Copy to clipboard", so this also covers the clipboard behaviour described in the issue, while letting campers send the link straight to Discord in one step.

### Implementation notes

- **No new dependency.** `share_plus` is already in `pubspec.yaml`, and this follows the same `SharePlus.instance.share(ShareParams(...))` pattern already used by the news tutorial view.
- **The button is gray**, per the review feedback on the earlier attempt at this issue. It reuses the existing `_panelIconButton` helper, so it picks up the same styling as the instruction/preview/console buttons beside it automatically.
- **The URL is no longer duplicated.** `genForumLink` already built the same `/learn/<superBlock>/<block>/<dashedName>` URL inline. That is now extracted into a `challengeUrl` helper in `challenge_utils.dart` and reused in both places.
- **The block name is included** alongside the challenge title, matching the naming `genForumLink` already uses. Sharing just "Step 1" would be ambiguous, since many workshops have a step with that title.
- **The tooltip is localized** through a new `share_challenge` key rather than hardcoded, in keeping with #1794. Only `app_en.arb` is edited by hand; `app_es.arb` and `app_pt.arb` are left to Crowdin.

### Scope

The button is added to `ChallengeView`, which covers the code-editor challenges and daily challenges. The alternative templates (python, english, multiple choice, quiz, review) each render their own bottom bar, so they are not affected. Happy to extend it to those in this PR if you would prefer.

### Testing

Verified on Flutter 3.44.9 (the version pinned in CI):
- `flutter analyze --no-fatal-warnings` reports no new issues
- `flutter test unit` (29 tests) and `flutter test services` (37 tests) pass, including a new unit test covering `challengeUrl`
- Ran the debug build on an Android 36 emulator and confirmed the button renders in the bottom bar with the same styling as its neighbours, and that the share sheet opens with the correct title and step URL

I have screenshots of the button and the share sheet and am happy to add them here.

<img width="1080" height="2400" alt="1-share-button-in-bottom-bar" src="https://github.com/user-attachments/assets/94130b7e-b73a-45bf-8e9c-7c512701d01a" />

<img width="1080" height="2400" alt="2-share-sheet-with-step-link" src="https://github.com/user-attachments/assets/99280237-89e2-4e6f-afc9-cfb866a50b88" />


