### PR TITLE
fix(l10n): add missing dash in not_available_web tooltip

### DIFF
--- a/mobile-app/lib/l10n/app_en.arb
+++ b/mobile-app/lib/l10n/app_en.arb
@@ -671,7 +671,7 @@
     "@temporarily_unavailable": {
         "description": "snackbar shown when a curriculum item is temporarily disabled"
     },
-    "not_available_web": "Not available use the web version",
+    "not_available_web": "Not available - use the web version",
     "@not_available_web": {
         "description": "snackbar shown when a curriculum item is only available on the web"
     },

--- a/mobile-app/lib/l10n/app_localizations.dart
+++ b/mobile-app/lib/l10n/app_localizations.dart
@@ -1070,7 +1070,7 @@ abstract class AppLocalizations {
   /// snackbar shown when a curriculum item is only available on the web
   ///
   /// In en, this message translates to:
-  /// **'Not available use the web version'**
+  /// **'Not available - use the web version'**
   String get not_available_web;
 
   /// learn landing heading for recommended curriculum stage

--- a/mobile-app/lib/l10n/app_localizations_en.dart
+++ b/mobile-app/lib/l10n/app_localizations_en.dart
@@ -577,7 +577,7 @@ class AppLocalizationsEn extends AppLocalizations {
       'Temporarily unavailable, come back soon.';
 
   @override
-  String get not_available_web => 'Not available use the web version';
+  String get not_available_web => 'Not available - use the web version';
 
   @override
   String get stage_core => 'Recommended curriculum (still in beta):';


### PR DESCRIPTION
{"body": "Checklist:\n\n- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).\n- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/how-to-open-a-pull-request/).\n- [x] My pull request targets the `main` branch of the repo.\n- [x] I have tested these changes locally on my machine.\n\nCloses #1827\n\n## Description of changes\n\nThe tooltip for courses that are not available on mobile read:\n\n> Not available use the web version\n\nwhich was missing a separator. It now reads:\n\n> Not available - use the web version\n\nmatching the existing `Coming soon - use the web version` phrasing mentioned in the issue.\n\nUpdated `app_en.arb` and the generated localization files (`app_localizations.dart`, `app_localizations_en.dart`). The es/pt arb files were intentionally left untouched since translations are managed through Crowdin."}